### PR TITLE
Switch to MySQL/TiDB backend, tighten admin/vendor flows, and UI/service-worker enhancements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,13 @@ JWT_SECRET=your_ultra_secure_jwt_secret
 ADMIN_SECRET=your_master_admin_key
 ADMIN_IP_WHITELIST=127.0.0.1,::1
 
-# --- DATABASE ---
-DB_PATH=./vault.sqlite
+# --- DATABASE (TiDB / MySQL) ---
+DB_HOST=127.0.0.1
+DB_USER=root
+DB_PASSWORD=change_me
+DB_NAME=xp_sensitivity_tool
+DB_PORT=4000
+DB_CONNECTION_LIMIT=10
 
 # --- WEBHOOKS ---
 # VENDOR_DISCORD_WEBHOOK=https://discord.com/api/webhooks/...

--- a/.env.template
+++ b/.env.template
@@ -1,16 +1,16 @@
 # XP SENSITIVITY TOOL PRO - Environment Configuration Template
 
 # Database Configuration (TiDB Cloud)
-DB_HOST=ygateway01.eu-central-1.prod.aws.tidbcloud.com
-DB_USER=2jDJxDFphxNiy1x.root
-DB_PASSWORD=7FwTqSXvXlh0km6p
+DB_HOST=your_tidb_host
+DB_USER=your_tidb_user
+DB_PASSWORD=your_tidb_password
 DB_NAME=xp_sensitivity_tool
 DB_PORT=4000
 DB_CONNECTION_LIMIT=10
 
 # Security
-JWT_SECRET=i am the admin
-ADMIN_SECRET=XP-2008
+JWT_SECRET=your_ultra_secure_jwt_secret
+ADMIN_SECRET=your_master_admin_key
 
 # Node Environment
 NODE_ENV=production

--- a/FINAL_PRODUCTION_DB_SETUP.sql
+++ b/FINAL_PRODUCTION_DB_SETUP.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS vendors (
     access_key VARCHAR(100) UNIQUE NOT NULL, -- bcrypt hash
     lookup_key VARCHAR(20) UNIQUE DEFAULT NULL,
     active_until DATETIME DEFAULT NULL,
+    webhook_url VARCHAR(500) DEFAULT NULL,
     brand_config JSON NOT NULL, 
     status ENUM('active', 'suspended') DEFAULT 'active',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -39,6 +40,7 @@ CREATE TABLE IF NOT EXISTS sensitivity_keys (
     lookup_key VARCHAR(16) UNIQUE NOT NULL,
     vendor_id VARCHAR(50),
     results_json JSON NOT NULL,
+    creator_advice TEXT DEFAULT NULL,
     custom_results_json JSON DEFAULT NULL,
     usage_limit INT DEFAULT NULL,
     current_usage INT DEFAULT 0,
@@ -110,10 +112,8 @@ CREATE TABLE IF NOT EXISTS system_settings (
 
 INSERT IGNORE INTO organizations (org_id, org_name, plan_tier) VALUES ('XP-CORE-ORG', 'XP ARENA GLOBAL', 'enterprise');
 
--- NOTE: Hashed Access Key for 'XP-2008' is $2b$10$8bg2W.b7yxuHVFNyj98qzuGpPSjXwFp.YVX9MahbBVqj1t5S/VtNi
--- For manual SQL, we provide the correct hash for XP-2008:
-INSERT IGNORE INTO vendors (org_id, vendor_id, access_key, lookup_key, brand_config, status) VALUES 
-('XP-CORE-ORG', 'XP-ADMIN', '$2b$10$8bg2W.b7yxuHVFNyj98qzuGpPSjXwFp.YVX9MahbBVqj1t5S/VtNi', '17a6f27ba4', '{"logo": "", "colors": {"primary": "#00f0ff"}, "socials": {}}', 'active');
+-- NOTE: Do NOT hardcode admin credentials in SQL.
+-- Provision XP-ADMIN vendor from environment secret in migrate.js (ADMIN_SECRET / SEED_VENDOR_KEY).
 
 INSERT IGNORE INTO system_settings (setting_key, setting_value) VALUES ('global_sensitivity_offset', '1.0');
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A professional-grade, mobile-first SaaS platform designed for high-precision har
 
 ## 🛠 Tech Stack
 - **Backend**: Node.js, Express, Socket.io
-- **Database**: SQLite3 (O(1) Optimized Hashing)
+- **Database**: MySQL/TiDB Cloud (mysql2 connection pool)
 - **Frontend**: Vanilla JS (ES6+), Three.js (3D Neural Hub)
 - **Security**: JWT, Bcrypt, Helmet, Rate-Limit
 

--- a/db.js
+++ b/db.js
@@ -20,16 +20,21 @@ const pool = mysql.createPool({
     }
 });
 
-// Diagnostic Connection Ping
-(async () => {
+// Diagnostic connection ping (skip during tests to avoid async logs after Jest teardown)
+async function runConnectionDiagnostic() {
     try {
         const conn = await pool.getConnection();
         console.log('✅ DB_CONNECTION_ESTABLISHED');
         conn.release();
     } catch (err) {
-        console.error('❌ DB_CONNECTION_FAILED:', err.message);
+        const msg = err && err.message ? err.message : 'UNKNOWN_DB_ERROR';
+        console.error('❌ DB_CONNECTION_FAILED:', msg);
     }
-})();
+}
+
+if (process.env.NODE_ENV !== 'test' && !process.env.JEST_WORKER_ID) {
+    runConnectionDiagnostic();
+}
 
 const databaseHelper = {
     async query(sql, params) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-export default [
+module.exports = [
   {
     files: ["**/*.js"],
     languageOptions: {

--- a/lib/calculator.js
+++ b/lib/calculator.js
@@ -33,6 +33,7 @@ const Calculator = {
         // Final result JSON
         const results = {
             formula_version: this.version,
+            global_offset_applied: Number(parseFloat(globalOffset || 1).toFixed(2)),
             brand: state.brand,
             model: state.model,
             general: range(baseRel, 200),
@@ -50,8 +51,13 @@ const Calculator = {
 
         // Manual Override Injection
         if (state.manualSens && !isNaN(parseFloat(state.manualSens))) {
-            const manualVal = parseFloat(state.manualSens);
+            const manualVal = parseFloat(state.manualSens) * parseFloat(globalOffset || 1);
             results.general = range(manualVal, 200);
+            results.redDot = range(manualVal * 0.95, 200);
+            results.scope2x = range(manualVal * 0.90, 200);
+            results.scope4x = range(manualVal * 0.88, 200);
+            results.sniperScope = range(manualVal * 0.6, 200);
+            results.freeLook = range(manualVal * 1.1, 200);
             results.isManual = true;
         }
 

--- a/migrate.js
+++ b/migrate.js
@@ -22,14 +22,27 @@ async function migrate() {
         console.log('Connecting to TiDB...');
         
         const dbName = process.env.DB_NAME || 'xp_sensitivity_tool';
-        let sql = fs.readFileSync(path.join(__dirname, 'vault.sql'), 'utf8');
-        sql = sql.replace(/CREATE DATABASE IF NOT EXISTS\s+\w+;/i, `CREATE DATABASE IF NOT EXISTS ${dbName};`);
-        sql = sql.replace(/USE\s+\w+;/i, `USE ${dbName};`);
-        console.log('Executing migration script...');
-        
-        await connection.query(sql);
-        
-        console.log('SUCCESS: All tables created and admin seeded.');
+        await connection.query(`CREATE DATABASE IF NOT EXISTS \`${dbName}\``);
+        await connection.query(`USE \`${dbName}\``);
+
+        const [existing] = await connection.query(
+            `SELECT COUNT(*) AS c
+             FROM information_schema.tables
+             WHERE table_schema = ? AND table_name = 'vendors'`,
+            [dbName]
+        );
+
+        if (!existing[0] || existing[0].c === 0) {
+            let sql = fs.readFileSync(path.join(__dirname, 'vault.sql'), 'utf8');
+            sql = sql.replace(/CREATE DATABASE IF NOT EXISTS\s+\w+;/i, `CREATE DATABASE IF NOT EXISTS ${dbName};`);
+            sql = sql.replace(/USE\s+\w+;/i, `USE ${dbName};`);
+            console.log('Fresh database detected. Executing full migration script...');
+            await connection.query(sql);
+        } else {
+            console.log('Existing database detected. Skipping full seed script (non-destructive mode).');
+        }
+
+        console.log('Schema alignment + seed normalization...');
         console.log('Database Name:', dbName);
 
         // Post-seed normalization: hash admin vendor key and set lookup_key
@@ -37,17 +50,31 @@ async function migrate() {
             // Align schema via ALTERs (idempotent)
             await connection.query(`ALTER TABLE vendors ADD COLUMN IF NOT EXISTS lookup_key VARCHAR(20) UNIQUE NULL`);
             await connection.query(`ALTER TABLE vendors ADD COLUMN IF NOT EXISTS active_until DATETIME NULL`);
+            await connection.query(`ALTER TABLE vendors ADD COLUMN IF NOT EXISTS webhook_url VARCHAR(500) NULL`);
             await connection.query(`ALTER TABLE sensitivity_keys ADD COLUMN IF NOT EXISTS lookup_key VARCHAR(16) UNIQUE NOT NULL`);
+            await connection.query(`ALTER TABLE sensitivity_keys ADD COLUMN IF NOT EXISTS creator_advice TEXT NULL`);
             await connection.query(`ALTER TABLE code_activity ADD COLUMN IF NOT EXISTS lookup_key VARCHAR(16) NOT NULL`);
             await connection.query(`ALTER TABLE code_activity ADD INDEX IF NOT EXISTS idx_lookup_key (lookup_key)`);
 
-            const [rows] = await connection.query('SELECT vendor_id, access_key FROM vendors WHERE vendor_id = ?', ['XP-ADMIN']);
-            if (rows && rows[0]) {
-                const rawKey = process.env.SEED_VENDOR_KEY || rows[0].access_key || 'XP-2008';
-                const hash = await bcrypt.hash(rawKey, 10);
-                const lookup = require('crypto').createHash('sha1').update(rawKey).digest('hex').substring(0, 10);
-                await connection.query('UPDATE vendors SET access_key = ?, lookup_key = ? WHERE vendor_id = ?', [hash, lookup, 'XP-ADMIN']);
-                console.log('Seed vendor normalized (hashed key + lookup_key set).');
+            const seedKey = process.env.SEED_VENDOR_KEY || process.env.ADMIN_SECRET || null;
+            const forceReset = process.env.FORCE_RESET_ADMIN_KEY === 'true';
+            const [rows] = await connection.query('SELECT vendor_id, access_key, lookup_key FROM vendors WHERE vendor_id = ?', ['XP-ADMIN']);
+            if (seedKey && (!rows[0] || forceReset)) {
+                const hash = await bcrypt.hash(seedKey, 10);
+                const lookup = require('crypto').createHash('sha1').update(seedKey).digest('hex').substring(0, 10);
+                if (!rows[0]) {
+                    await connection.query(
+                        `INSERT INTO vendors (org_id, vendor_id, access_key, lookup_key, brand_config, status)
+                         VALUES ('XP-CORE-ORG', 'XP-ADMIN', ?, ?, '{}', 'active')`,
+                        [hash, lookup]
+                    );
+                    console.log('XP-ADMIN seed inserted from environment secret.');
+                } else {
+                    await connection.query('UPDATE vendors SET access_key = ?, lookup_key = ? WHERE vendor_id = ?', [hash, lookup, 'XP-ADMIN']);
+                    console.log('XP-ADMIN key rotated from environment secret.');
+                }
+            } else if (!seedKey) {
+                console.log('No ADMIN_SECRET/SEED_VENDOR_KEY provided. Skipping XP-ADMIN seed key creation.');
             }
         } catch (e) {
             console.warn('Seed normalization skipped:', e.message);

--- a/public/admin.html
+++ b/public/admin.html
@@ -509,6 +509,12 @@
             <div id="funnelSteps" class="stat-tile" style="padding: 1.5rem;">
                 <!-- Funnel injected -->
             </div>
+            <div class="live-feed-header" style="margin-top: 1.25rem;">
+                <span class="stat-label">Security Logs</span>
+            </div>
+            <div id="securityLogs" class="stat-tile" style="padding: 1rem; max-height: 220px; overflow-y: auto;">
+                <div style="text-align:center; opacity:0.2; padding:2rem; font-size:0.6rem;">NO_SECURITY_EVENTS</div>
+            </div>
         </div>
     </div>
 
@@ -561,31 +567,19 @@
         </div>
     </div>
 
-    <script src="/socket.io/socket.io.js"></script>
     <script src="notifications.js"></script>
     <script src="settings.js"></script>
     <script>
         // ⚡ Master Interface Logic
-        const socket = typeof io !== 'undefined' ? io() : { on: () => {} };
-        
-        // Socket Live Feed
-        socket.on('live_event', (data) => {
-            const feed = document.getElementById('liveFeed');
-            if (feed.children[0] && feed.children[0].textContent.includes('WAITING')) feed.innerHTML = '';
-            
-            const item = document.createElement('div');
-            item.className = 'live-item';
-            
-            if (data.type === 'verify') {
-                item.innerHTML = `<span>[HIT] ${data.user_ign}</span><span style="color:var(--accent-primary)">${data.device}</span>`;
-            } else if (data.type === 'feedback') {
-                item.innerHTML = `<span>[FBK] ${'★'.repeat(data.rating)}</span><span style="color:#aaa">"${data.feedback}"</span>`;
-            }
-            
-            feed.prepend(item);
-            if (feed.children.length > 15) feed.removeChild(feed.lastChild);
-            loadDashboard(); // Refresh stats
-        });
+        let dashboardPoller = null;
+        function startLongPolling() {
+            if (dashboardPoller) return;
+            dashboardPoller = setInterval(() => {
+                if (!document.getElementById('mainPanel').classList.contains('hidden')) {
+                    loadDashboard().catch(() => {});
+                }
+            }, 10000);
+        }
 
         async function api(path, method = 'GET', body = null) {
             const options = {
@@ -596,7 +590,19 @@
             if (body) options.body = JSON.stringify(body);
             const res = await fetch(path, options);
             if (res.status === 401) return logoutAdmin();
-            if (!res.ok) throw new Error((await res.json()).error || 'API_ERR');
+            if (!res.ok) {
+                let errMsg = 'API_ERR';
+                try {
+                    const data = await res.json();
+                    errMsg = data.error || data.message || errMsg;
+                } catch (_e) {
+                    try {
+                        const txt = await res.text();
+                        if (txt) errMsg = txt.slice(0, 120);
+                    } catch (__e) {}
+                }
+                throw new Error(errMsg);
+            }
             return res.json();
         }
 
@@ -615,6 +621,7 @@
                 if (res.ok) {
                     document.getElementById('privateGate').classList.add('hidden');
                     document.getElementById('mainPanel').classList.remove('hidden');
+                    startLongPolling();
                     loadDashboard();
                     initTool();
                 } else {
@@ -637,6 +644,13 @@
             if (targetSection) targetSection.classList.remove('hidden');
             document.querySelectorAll('.nav-item').forEach(n => n.classList.remove('active'));
             if (el) el.classList.add('active');
+            if (tabId === 'tool') initTool();
+            if (tabId === 'analytics') {
+                loadSecurityLogs();
+            }
+            if (tabId === 'vendors') {
+                loadDashboard();
+            }
         }
 
         function toggleActionSheet(show) {
@@ -687,16 +701,19 @@
                 const funnel = document.getElementById('funnelSteps');
                 if (orgStats && orgStats.funnel && orgStats.funnel.length > 0) {
                     const maxVal = orgStats.funnel[0].val || 1;
+                    let prev = maxVal;
                     funnel.innerHTML = orgStats.funnel.map(step => {
-                        const pct = Math.round((step.val / maxVal) * 100);
+                        const pctOfStart = Math.round((step.val / maxVal) * 100);
+                        const conv = prev > 0 ? Math.round((step.val / prev) * 100) : 0;
+                        prev = step.val || prev;
                         return `
                             <div style="margin-bottom: 1rem;">
                                 <div style="display:flex; justify-content:space-between; font-size: 0.65rem; margin-bottom: 0.3rem;">
                                     <span style="font-weight:800;">${step.label}</span>
-                                    <span style="color:var(--accent-primary)">${step.val} (${pct}%)</span>
+                                    <span style="color:var(--accent-primary)">${step.val} (${pctOfStart}% of start / ${conv}% step)</span>
                                 </div>
                                 <div style="height: 4px; background: rgba(255,255,255,0.05); border-radius: 2px; overflow:hidden;">
-                                    <div style="width:${pct}%; height:100%; background:var(--accent-primary); box-shadow: 0 0 10px var(--accent-primary-glow);"></div>
+                                    <div style="width:${pctOfStart}%; height:100%; background:var(--accent-primary); box-shadow: 0 0 10px var(--accent-primary-glow);"></div>
                                 </div>
                             </div>
                         `;
@@ -704,7 +721,46 @@
                 } else if (funnel) {
                     funnel.innerHTML = '<div style="text-align:center; opacity:0.2; padding:2rem; font-size:0.6rem;">NO_ANALYTICS_DATA</div>';
                 }
+                await loadLiveFeed();
+                await loadSecurityLogs();
             } catch (e) { console.error('INIT_ERR:', e); }
+        }
+
+        async function loadLiveFeed() {
+            const feed = document.getElementById('liveFeed');
+            if (!feed) return;
+            try {
+                const events = await api('/api/vault/admin/live-feed');
+                if (!events || events.length === 0) {
+                    feed.innerHTML = '<div style="text-align:center; opacity:0.2; padding:2rem; font-size:0.6rem;">WAITING_FOR_UPLINK...</div>';
+                    return;
+                }
+                feed.innerHTML = events.map(ev => `
+                    <div class="live-item">
+                        <span>${ev.type === 'feedback' ? `[FBK] ${'★'.repeat(ev.rating || 0)}` : `[HIT] ${ev.user_ign}`}</span>
+                        <span style="color:${ev.type === 'feedback' ? '#aaa' : 'var(--accent-primary)'};">${ev.type === 'feedback' ? (ev.feedback || 'No comment') : (ev.region || 'Unknown')}</span>
+                    </div>
+                `).join('');
+            } catch (_e) {}
+        }
+
+        async function loadSecurityLogs() {
+            const box = document.getElementById('securityLogs');
+            if (!box) return;
+            try {
+                const logs = await api('/api/vault/admin/security-logs');
+                if (!logs || logs.length === 0) {
+                    box.innerHTML = '<div style="text-align:center; opacity:0.2; padding:2rem; font-size:0.6rem;">NO_SECURITY_EVENTS</div>';
+                    return;
+                }
+                box.innerHTML = logs.map(l => `
+                    <div style="padding:0.6rem 0.2rem; border-bottom:1px solid rgba(255,255,255,0.05); display:flex; justify-content:space-between; gap:0.75rem; font-size:0.62rem;">
+                        <span style="font-family:var(--font-mono); color:var(--text-muted);">${new Date(l.created_at).toLocaleTimeString()}</span>
+                        <span style="font-weight:700;">${l.event_type}</span>
+                        <span style="font-family:var(--font-mono); color:#ff8a8a;">${l.ip_address || 'unknown-ip'}</span>
+                    </div>
+                `).join('');
+            } catch (_e) {}
         }
 
         function renderVendorCards(vendors, creators) {
@@ -744,14 +800,26 @@
         }
 
         async function addVendor() {
-            const vid = document.getElementById('vName').value;
-            if (!vid) return alert("NAME_REQUIRED");
+            const vid = document.getElementById('vName').value.trim();
+            const brand = document.getElementById('vBrand').value.trim();
+            const vLimit = parseInt(document.getElementById('vLimit').value, 10);
+            if (!vid || vid.length < 2) return alert("NAME_REQUIRED (MIN 2 CHARS)");
             try {
-                const res = await api('/api/vault/admin/vendors', 'POST', { vendorId: vid });
+                const payload = {
+                    vendorId: vid,
+                    brandConfig: {
+                        display_name: brand || vid,
+                        limit_hint: Number.isFinite(vLimit) ? vLimit : null
+                    }
+                };
+                const res = await api('/api/vault/admin/vendors', 'POST', payload);
                 alert(`PROVISIONED: ${res.accessKey}`);
+                document.getElementById('vName').value = '';
+                document.getElementById('vBrand').value = '';
+                document.getElementById('vLimit').value = '';
                 toggleActionSheet(false);
                 loadDashboard();
-            } catch (e) { alert(e.message); }
+            } catch (e) { alert(`VENDOR_CREATE_FAILED: ${e.message}`); }
         }
 
         async function toggleStatus(id, current) {
@@ -762,7 +830,7 @@
 
         async function deleteVendor(id) {
             if (!confirm(`ERASE ${id} FOREVER?`)) return;
-            await api(`/api/vault/admin/vendor/${id}`, 'DELETE');
+            await api(`/api/vault/admin/vendor/${encodeURIComponent(id)}`, 'DELETE');
             loadDashboard();
         }
 

--- a/public/app.js
+++ b/public/app.js
@@ -68,6 +68,13 @@ document.getElementById('pwaInstallBtn')?.addEventListener('click', async () => 
             document.getElementById('pwaInstallBtn').style.display = 'none';
         }
         deferredPrompt = null;
+    } else {
+        const isIOS = /iphone|ipad|ipod/i.test(navigator.userAgent);
+        if (isIOS) {
+            UI?.notify?.("INSTALL TIP: TAP SHARE → 'ADD TO HOME SCREEN'", 'info');
+        } else {
+            UI?.notify?.("INSTALL OPTION NOT AVAILABLE IN THIS BROWSER", 'info');
+        }
     }
 });
 
@@ -83,6 +90,7 @@ const UI = {
         brand: document.getElementById('brandSelect'),
         series: document.getElementById('seriesSelect'),
         model: document.getElementById('modelSelect'),
+        ramSelect: document.getElementById('ramSelect'),
         
         sensInput: document.getElementById('sensInput'),
         sensLabel: document.getElementById('sensLabel'),
@@ -263,11 +271,12 @@ const UI = {
     },
 
     attachCalibrationListeners() {
-        const { brand, series, model, sensInput, manualSens, calculateBtn, gripBtns } = this.elements;
+        const { brand, series, model, ramSelect, sensInput, manualSens, calculateBtn, gripBtns } = this.elements;
 
         brand.addEventListener('change', () => {
             state.brand = brand.value;
             this.updateSeriesDropdown();
+            this.autoSetRamForModel();
         });
 
         series.addEventListener('change', () => {
@@ -277,8 +286,15 @@ const UI = {
 
         model.addEventListener('change', () => {
             state.model = model.value;
+            this.autoSetRamForModel();
             this.saveProfile();
         });
+
+        if (ramSelect) {
+            ramSelect.addEventListener('change', () => {
+                state.ram = parseInt(ramSelect.value, 10) || 8;
+            });
+        }
 
         sensInput.addEventListener('input', (e) => {
             state.neuralScale = parseFloat(e.target.value);
@@ -343,6 +359,37 @@ const UI = {
         model.disabled = false;
     },
 
+    estimateRamByModel() {
+        const brand = (state.brand || '').toLowerCase();
+        const model = (state.model || '').toLowerCase();
+        if (!model) return 8;
+        if (brand === 'apple') {
+            if (model.includes('17') || model.includes('16') || model.includes('15 pro') || model.includes('14 pro')) return 8;
+            if (model.includes('13 pro') || model.includes('12 pro')) return 6;
+            return 4;
+        }
+        if (/(ultra|pro\+|rog|redmagic|gaming|gt|x100|12|11|10 pro)/.test(model)) return 12;
+        if (/(plus|note|neo|f\d|x\d|v\d|reno|nord|pova|camon)/.test(model)) return 8;
+        return 6;
+    },
+
+    autoSetRamForModel() {
+        const ramGroup = document.getElementById('ramGroup');
+        const ramSelect = this.elements.ramSelect;
+        if (!ramSelect || !ramGroup) return;
+
+        if ((state.brand || '').toLowerCase() === 'apple') {
+            state.ram = this.estimateRamByModel();
+            ramSelect.value = String(state.ram);
+            ramGroup.style.display = 'none';
+            return;
+        }
+
+        ramGroup.style.display = 'block';
+        state.ram = this.estimateRamByModel();
+        ramSelect.value = String(state.ram);
+    },
+
     async handleCalculate() {
         if (!state.manualMode && (!state.brand || !state.model)) {
             this.notify("INCOMPLETE PROFILE: SELECT BRAND AND MODEL", "error");
@@ -360,14 +407,19 @@ const UI = {
         this.notify("NEURAL CALIBRATION IN PROGRESS...", "success");
         
         try {
+            const payload = {
+                ...state,
+                manualSens: state.manualMode ? Number.parseFloat(state.manualSens) : undefined
+            };
             const res = await fetch('/api/vault/calculate', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(state)
+                body: JSON.stringify(payload)
             });
             const data = await res.json();
             
             if (data.results) {
+                if (window.SaaSAnalytics) window.SaaSAnalytics.track('code_generated');
                 localStorage.setItem('xp_sensitivity_profile_last_result', JSON.stringify(data.results));
                 localStorage.setItem('xp_sensitivity_profile', JSON.stringify(state));
                 localStorage.setItem('xp_last_entry_code', data.entry_code); // 🚀 Store for Result Page
@@ -403,6 +455,10 @@ const UI = {
             this.elements.sensInput.value = state.neuralScale;
             this.elements.sensLabel.textContent = state.neuralScale.toFixed(1);
         }
+        if (this.elements.ramSelect) {
+            this.elements.ramSelect.value = String(state.ram || 8);
+        }
+        this.autoSetRamForModel();
     },
        initLanguage() {
         this.applyLang();
@@ -427,6 +483,8 @@ const UI = {
         // 🛡️ Special Case Handling (Selects, etc)
         const brandLabel = document.querySelector('#hardwareSection .form-group .form-label');
         if (brandLabel) brandLabel.textContent = dict.brandLabel || 'Device Architecture';
+        const ramLabel = document.querySelector('#ramGroup .form-label');
+        if (ramLabel) ramLabel.textContent = dict.ramLabel || 'Hardware RAM';
         
         const calcBtn = document.getElementById('calculateBtn');
         if (calcBtn) calcBtn.textContent = dict.calcBtn || 'GENERATE OPTIMIZED GUIDE';
@@ -460,6 +518,7 @@ const UI = {
         }
     }
 };
+window.UI = UI;
 
 window.toggleLowPerf = () => {
     const isLow = localStorage.getItem('xp_low_perf') === 'true';
@@ -478,6 +537,12 @@ window.toggleLowPerf = () => {
 
 document.addEventListener('DOMContentLoaded', () => {
     UI.init();
+    const isIOS = /iphone|ipad|ipod/i.test(navigator.userAgent);
+    const btn = document.getElementById('pwaInstallBtn');
+    if (btn && isIOS) {
+        btn.style.display = 'block';
+        btn.textContent = 'INSTALL: SHARE → A2HS';
+    }
     
     // ⚡ Adaptive Performance Check
     if (localStorage.getItem('xp_low_perf') === 'true') {
@@ -487,5 +552,11 @@ document.addEventListener('DOMContentLoaded', () => {
             if (btn) btn.textContent = 'MODE: LOW_LATENCY';
             document.body.style.background = 'var(--bg-dark)';
         }, 100);
+    }
+});
+
+window.addEventListener('xp:language-change', () => {
+    if (window.UI && typeof window.UI.applyLang === 'function') {
+        window.UI.applyLang();
     }
 });

--- a/public/index.html
+++ b/public/index.html
@@ -46,6 +46,84 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="apple-touch-icon" href="icons/icon-192.png">
     <link rel="stylesheet" href="styles.css">
+    <style>
+        .premium-shell {
+            position: relative;
+            isolation: isolate;
+        }
+        .premium-shell::before,
+        .premium-shell::after {
+            content: "";
+            position: absolute;
+            width: 320px;
+            height: 320px;
+            border-radius: 50%;
+            filter: blur(70px);
+            z-index: -1;
+            pointer-events: none;
+            opacity: 0.35;
+        }
+        .premium-shell::before {
+            top: -120px;
+            right: -80px;
+            background: radial-gradient(circle, rgba(0,240,255,.55), transparent 65%);
+        }
+        .premium-shell::after {
+            bottom: 180px;
+            left: -120px;
+            background: radial-gradient(circle, rgba(255,170,0,.45), transparent 68%);
+        }
+        .premium-card {
+            background: linear-gradient(160deg, rgba(255,255,255,0.06), rgba(255,255,255,0.01));
+            border: 1px solid rgba(255,255,255,0.12);
+            border-radius: 24px;
+            box-shadow: 0 20px 50px rgba(0,0,0,0.35);
+            backdrop-filter: blur(14px);
+        }
+        .hero-headline {
+            font-size: clamp(2rem, 5vw, 3rem);
+            line-height: 1.05;
+            letter-spacing: -0.03em;
+            margin: .6rem 0 .7rem;
+        }
+        .hero-sub {
+            max-width: 560px;
+            margin: 0 auto;
+            color: var(--text-secondary);
+            font-size: .92rem;
+        }
+        .kpi-row {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: .7rem;
+            margin-top: 1.2rem;
+        }
+        .kpi {
+            border: 1px solid rgba(255,255,255,.08);
+            border-radius: 14px;
+            padding: .75rem .5rem;
+            background: rgba(255,255,255,.02);
+        }
+        .kpi .val {
+            font-family: var(--font-heading);
+            color: var(--accent-primary);
+            font-size: .95rem;
+            display: block;
+            margin-bottom: .22rem;
+        }
+        .kpi .label {
+            font-size: .58rem;
+            color: var(--text-muted);
+            letter-spacing: .08em;
+            text-transform: uppercase;
+        }
+        .premium-footer-note {
+            padding: 0.85rem 1rem;
+            border: 1px dashed rgba(255,255,255,.12);
+            border-radius: 14px;
+            background: rgba(255,255,255,.01);
+        }
+    </style>
 </head>
 <body>
     <div class="ambient-glow"></div>
@@ -80,12 +158,17 @@
     </div>
 
     <!-- Main Calibration UI -->
-    <div id="appContainer" class="app-container hidden">
-        <header style="text-align: center; margin-bottom: var(--space-lg); position: relative;">
+    <div id="appContainer" class="app-container hidden premium-shell">
+        <header class="premium-card" style="text-align: center; margin-bottom: var(--space-lg); position: relative; padding: 1.3rem 1rem 1.2rem;">
             <button id="pwaInstallBtn" class="logo-badge" style="display: none; border-color: var(--accent-primary); color: var(--accent-primary); cursor: pointer; margin-bottom: 1rem; position: absolute; right: 0; top: 0; font-size: 0.6rem;">INSTALL APP</button>
-            <div class="logo-badge">SYSTEM ENGINE V4.0</div>
-            <h1 class="title-main" data-i18n="title">NEURAL<br>CALIBRATION</h1>
-            <p data-i18n="heroSubtitle" style="color: var(--text-secondary); font-size: 0.9rem;">Optimizing benchmarks for your specific hardware architecture.</p>
+            <div class="logo-badge" style="margin-top: .2rem;">SYSTEM ENGINE V4.0</div>
+            <h1 class="title-main hero-headline" data-i18n="title">NEURAL<br>CALIBRATION</h1>
+            <p data-i18n="heroSubtitle" class="hero-sub">Optimizing benchmarks for your specific hardware architecture.</p>
+            <div class="kpi-row">
+                <div class="kpi"><span class="val">AI V4</span><span class="label">Predictive Core</span></div>
+                <div class="kpi"><span class="val">~10ms</span><span class="label">Response Path</span></div>
+                <div class="kpi"><span class="val">24/7</span><span class="label">Cloud Active</span></div>
+            </div>
         </header>
 
         <main>
@@ -113,6 +196,19 @@
                         <div class="select-container">
                             <select id="modelSelect" class="cyber-select" disabled>
                                 <option value="" data-i18n="modelLabel">SELECT MODEL</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="form-group" id="ramGroup">
+                        <label class="form-label" data-i18n="ramLabel">Hardware RAM</label>
+                        <div class="select-container">
+                            <select id="ramSelect" class="cyber-select">
+                                <option value="4">4 GB</option>
+                                <option value="6">6 GB</option>
+                                <option value="8" selected>8 GB</option>
+                                <option value="12">12 GB</option>
+                                <option value="16">16 GB</option>
                             </select>
                         </div>
                     </div>
@@ -161,7 +257,7 @@
                 </div>
             </section>
 
-            <button id="calculateBtn" class="action-btn reveal" data-i18n="calcBtn" style="animation-delay: 0.3s;">
+            <button id="calculateBtn" class="action-btn reveal premium-card" data-i18n="calcBtn" style="animation-delay: 0.3s; border-radius: 18px;">
                 GENERATE OPTIMIZED GUIDE
             </button>
         </main>
@@ -181,9 +277,9 @@
                 <a href="#" onclick="UI.notify('TERMS_OF_SERVICE_ACKNOWLEDGED', 'info')" style="color: inherit; text-decoration: none;">TERMS</a>
                 <a href="#" onclick="UI.notify('NEURAL_SUPPORT_LINK_ACTIVE', 'info')" style="color: var(--accent-primary); text-decoration: none;">SUPPORT</a>
             </div>
-            <p style="letter-spacing: 0.2em; font-weight: 800; color: white;">POWERED BY XP ARENA GLOBAL CLOUD</p>
-        </footer>
-CLOUD</p>
+            <div class="premium-footer-note">
+                <p style="letter-spacing: 0.15em; font-weight: 800; color: white; margin:0;">POWERED BY XP ARENA GLOBAL CLOUD</p>
+            </div>
         </footer>
     </div>
 

--- a/public/result.html
+++ b/public/result.html
@@ -130,6 +130,8 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <script src="analytics.js"></script>
+    <script src="translations.js"></script>
     <script src="notifications.js"></script>
     <script src="settings.js"></script>
     <script>
@@ -138,11 +140,48 @@
             const state = JSON.parse(localStorage.getItem('xp_sensitivity_profile') || '{}');
             const branding = JSON.parse(localStorage.getItem('xp_last_branding') || '{}');
             const code = localStorage.getItem('xp_last_entry_code') || 'FREE-GEN';
+            const getDict = () => {
+                const lang = localStorage.getItem('xp_lang') || 'en';
+                return (window.LANGUAGES && window.LANGUAGES[lang]) || window.LANGUAGES?.en || {};
+            };
+            const t = (key, fallback) => {
+                const d = getDict();
+                return d[key] || fallback;
+            };
 
             if (!results.general) {
                 window.location.href = 'index.html';
                 return;
             }
+            if (window.SaaSAnalytics) window.SaaSAnalytics.track('result_view');
+
+            const applyResultLang = () => {
+                const title = document.querySelector('.title-main');
+                if (title) title.textContent = t('resultsTitle', 'AUTHORIZATION_SUCCESS');
+                const downloadBtn = document.getElementById('downloadBtn');
+                if (downloadBtn) downloadBtn.textContent = t('downloadBtn', 'DOWNLOAD_ID');
+                const copyBtn = document.getElementById('copyBtn');
+                if (copyBtn) copyBtn.textContent = `${t('copyBtn', 'COPY_TEXT')} / SHARE`;
+            };
+            applyResultLang();
+            window.addEventListener('xp:language-change', applyResultLang);
+
+            const parseRange = (v) => {
+                if (typeof v === 'number' && Number.isFinite(v)) return [Math.max(0, v - 3), Math.min(200, v + 3)];
+                if (typeof v === 'string') {
+                    const m = v.match(/^\s*(\d+)\s*-\s*(\d+)\s*$/);
+                    if (m) return [parseInt(m[1], 10), parseInt(m[2], 10)];
+                    const n = Number.parseFloat(v);
+                    if (Number.isFinite(n)) return [Math.max(0, Math.round(n - 3)), Math.min(200, Math.round(n + 3))];
+                }
+                return ['--', '--'];
+            };
+
+            const paintRange = (id1, id2, val) => {
+                const [a, b] = parseRange(val);
+                document.getElementById(id1).textContent = a;
+                document.getElementById(id2).textContent = b;
+            };
 
             // Populate Card Info
             document.getElementById('idModel').textContent = `${state.brand || 'GENERIC'} ${state.model || 'DEVICE'}`.toUpperCase();
@@ -150,13 +189,20 @@
             document.getElementById('creatorName').textContent = branding.display_name || branding.name || 'XP_CORE';
             if (branding.logo_url || branding.logo) document.getElementById('creatorLogo').src = branding.logo_url || branding.logo;
             if (results.advice) document.getElementById('creatorAdvice').textContent = `"${results.advice}"`;
+            paintRange('rGen1', 'rGen2', results.general);
+            paintRange('rRed1', 'rRed2', results.redDot);
+            paintRange('r2x1', 'r2x2', results.scope2x);
+            paintRange('r4x1', 'r4x2', results.scope4x);
+            paintRange('rSni1', 'rSni2', results.sniperScope || results.sniper);
+            paintRange('rFree1', 'rFree2', results.freeLook);
 
             // Social Icons Injection
             const socialBox = document.getElementById('socialLinks');
+            const socialsObj = branding.socials || {};
             const socials = [
-                { id: 'youtube', icon: 'YouTube', link: branding.youtube },
-                { id: 'tiktok', icon: 'TikTok', link: branding.tiktok },
-                { id: 'discord', icon: 'Discord', link: branding.discord }
+                { id: 'youtube', icon: 'YouTube', link: branding.youtube || socialsObj.yt },
+                { id: 'tiktok', icon: 'TikTok', link: branding.tiktok || socialsObj.tiktok || socialsObj.tt },
+                { id: 'discord', icon: 'Discord', link: branding.discord || socialsObj.discord || socialsObj.dc }
             ];
 
             const socialIcons = {
@@ -178,8 +224,9 @@
 
             // Follow Button
             const followBtn = document.getElementById('followBtn');
-            if (branding.youtube || branding.tiktok || branding.discord || branding.social_link) {
-                const primaryLink = branding.youtube || branding.tiktok || branding.discord || branding.social_link;
+            const primarySocial = socials.find(s => s.link)?.link;
+            if (primarySocial || branding.social_link) {
+                const primaryLink = primarySocial || branding.social_link;
                 followBtn.onclick = () => window.open(primaryLink.startsWith('http') ? primaryLink : `https://${primaryLink}`, '_blank');
             } else {
                 followBtn.textContent = 'JOIN_COMMUNITY';
@@ -205,8 +252,10 @@
 
             // Copy Logic with "Haptic" Toast
             document.getElementById('copyBtn').onclick = () => {
-                const text = `XP ARENA ACCESS PROFILE\nDEVICE: ${state.brand || 'UNKNOWN'} ${state.model || 'DEVICE'}\nGENERAL: ${(results.general || 0)-3}-${(results.general || 0)+3}\nRED DOT: ${(results.redDot || 0)-3}-${(results.redDot || 0)+3}\nCODE: ${code}`;
-                navigator.clipboard.writeText(text).then(() => {
+                const general = `${document.getElementById('rGen1').textContent}-${document.getElementById('rGen2').textContent}`;
+                const redDot = `${document.getElementById('rRed1').textContent}-${document.getElementById('rRed2').textContent}`;
+                const text = `XP ARENA ACCESS PROFILE\nDEVICE: ${state.brand || 'UNKNOWN'} ${state.model || 'DEVICE'}\nGENERAL: ${general}\nRED DOT: ${redDot}\nCODE: ${code}`;
+                const doAfter = () => {
                     // Track Conversion Ping
                     try {
                         fetch('/api/vault/action', {
@@ -219,7 +268,18 @@
                     if (window.notify) {
                         window.notify('PROFILE_COPIED_TO_CLIPBOARD', 'haptic');
                     }
-                });
+                };
+
+                if (navigator.share) {
+                    navigator.share({
+                        title: 'XP ARENA Calibration Profile',
+                        text
+                    }).then(doAfter).catch(() => {
+                        navigator.clipboard.writeText(text).then(doAfter);
+                    });
+                } else {
+                    navigator.clipboard.writeText(text).then(doAfter);
+                }
             };
         });
     </script>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'xp-arena-v1';
+const CACHE_NAME = 'xp-arena-v2';
 const ASSETS = [
     '/',
     '/index.html',
@@ -13,6 +13,7 @@ self.addEventListener('install', (e) => {
     e.waitUntil(
         caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
     );
+    self.skipWaiting();
 });
 
 self.addEventListener('activate', (e) => {
@@ -23,6 +24,7 @@ self.addEventListener('activate', (e) => {
             );
         })
     );
+    self.clients.claim();
 });
 
 self.addEventListener('fetch', (e) => {
@@ -36,14 +38,29 @@ self.addEventListener('fetch', (e) => {
         return;
     }
 
+    // Network-first for HTML to avoid stale UI after deployments.
+    if (e.request.destination === 'document') {
+        e.respondWith(
+            fetch(e.request)
+                .then(res => {
+                    const cloned = res.clone();
+                    caches.open(CACHE_NAME).then(cache => cache.put(e.request, cloned));
+                    return res;
+                })
+                .catch(() => caches.match(e.request).then(r => r || caches.match('/index.html')))
+        );
+        return;
+    }
+
+    // Stale-while-revalidate for static assets.
     e.respondWith(
-        caches.match(e.request).then(res => {
-            return res || fetch(e.request).catch(() => {
-                // If offline and request fails, try serving the index.html explicitly
-                if (e.request.destination === 'document') {
-                    return caches.match('/index.html');
-                }
-            });
+        caches.match(e.request).then(cached => {
+            const networkFetch = fetch(e.request).then(res => {
+                const cloned = res.clone();
+                caches.open(CACHE_NAME).then(cache => cache.put(e.request, cloned));
+                return res;
+            }).catch(() => cached);
+            return cached || networkFetch;
         })
     );
 });

--- a/public/settings.js
+++ b/public/settings.js
@@ -34,9 +34,13 @@
 
     function applyLang(langCode) {
         localStorage.setItem('xp_lang', langCode);
-        // If app.js is present and initialized, we could call UI.applyLang()
-        // But location.reload() is safer for a global effect across different page structures
-        location.reload();
+        document.querySelectorAll('.lang-item').forEach(item => {
+            item.classList.toggle('active', item.dataset.lang === langCode);
+        });
+        if (window.UI && typeof window.UI.applyLang === 'function') {
+            window.UI.applyLang();
+        }
+        window.dispatchEvent(new CustomEvent('xp:language-change', { detail: { lang: langCode } }));
     }
 
     // Inject Settings Hub UI

--- a/public/vendor_dashboard.html
+++ b/public/vendor_dashboard.html
@@ -453,12 +453,17 @@
                 <input type="text" id="profDC" class="cyber-input" placeholder="discord.gg/invite">
             </div>
 
+            <div class="form-control">
+                <label>WEBHOOK URL</label>
+                <input type="url" id="profWebhook" class="cyber-input" placeholder="https://example.com/webhook">
+            </div>
+
             <button class="btn-primary" onclick="saveProfile()" style="margin-top: 1rem;">UPDATE_PRO_PROFILE</button>
         </div>
 
         <div class="glass-panel" style="background: rgba(255, 255, 255, 0.01);">
             <h3 style="margin: 0 0 1rem; font-size: 0.7rem; color: var(--text-muted);">SECURITY_RESOURCES</h3>
-            <button class="btn-primary" style="background: var(--glass-bg); color: #fff; box-shadow: none; font-size: 0.7rem; margin-bottom: 0.5rem;" onclick="logoutAdmin()">REVOKE_ACCESS_TOKEN</button>
+            <button class="btn-primary" style="background: var(--glass-bg); color: #fff; box-shadow: none; font-size: 0.7rem; margin-bottom: 0.5rem;" onclick="handleLogout()">REVOKE_ACCESS_TOKEN</button>
         </div>
     </div>
 
@@ -589,6 +594,7 @@
                     document.getElementById('profYT').value = profile.youtube || '';
                     document.getElementById('profTT').value = profile.tiktok || '';
                     document.getElementById('profDC').value = profile.discord || '';
+                    document.getElementById('profWebhook').value = profile.webhook_url || '';
                 }
             } catch (e) {
                 console.warn('LOAD_PROFILE_ERR:', e);
@@ -597,14 +603,17 @@
 
         async function saveProfile() {
             const data = {
-                display_name: document.getElementById('profName').value,
-                logo_url: document.getElementById('profLogo').value,
-                youtube: document.getElementById('profYT').value,
-                tiktok: document.getElementById('profTT').value,
-                discord: document.getElementById('profDC').value
+                brand_config: {
+                    display_name: document.getElementById('profName').value.trim(),
+                    logo_url: document.getElementById('profLogo').value.trim(),
+                    youtube: document.getElementById('profYT').value.trim(),
+                    tiktok: document.getElementById('profTT').value.trim(),
+                    discord: document.getElementById('profDC').value.trim()
+                },
+                webhook_url: document.getElementById('profWebhook').value.trim() || null
             };
             try {
-                await api(`${API_BASE}/vendor/profile`, 'POST', data);
+                await api(`${API_BASE}/profile`, 'PUT', data);
                 if (window.notify) window.notify('PROFILE_UPDATED_SYNCED', 'success');
                 loadDashboard(); // Refresh UI
             } catch (e) {

--- a/routes/vaultRoutes.js
+++ b/routes/vaultRoutes.js
@@ -37,7 +37,24 @@ function parseBearer(header) {
 }
 
 function getJwtSecret() {
-    return process.env.JWT_SECRET || 'xparena_ultra_secure_777';
+    return process.env.JWT_SECRET || getAdminSecret();
+}
+
+function getAdminSecret() {
+    return process.env.ADMIN_SECRET || '';
+}
+
+function normalizeBranding(config) {
+    if (!config) return {};
+    const c = typeof config === 'string' ? JSON.parse(config) : config;
+    const socials = c.socials || {};
+    return {
+        ...c,
+        youtube: c.youtube || socials.yt || '',
+        tiktok: c.tiktok || socials.tiktok || socials.tt || '',
+        discord: c.discord || socials.discord || socials.dc || '',
+        logo_url: c.logo_url || c.logo || ''
+    };
 }
 
 function authenticateVendor(req, res, next) {
@@ -107,6 +124,8 @@ async function dispatchVendorWebhook(vendorId, eventType, data) {
 
 function authenticateAdmin(req, res, next) {
     try {
+        const adminSecret = getAdminSecret();
+        if (!adminSecret) return res.status(503).json({ error: 'ADMIN_SECRET_NOT_CONFIGURED' });
         // IP Whitelist Check (10/10 Security)
         const whitelist = process.env.ADMIN_IP_WHITELIST;
         if (whitelist && whitelist !== '*') {
@@ -120,7 +139,7 @@ function authenticateAdmin(req, res, next) {
 
         const token = req.cookies.xp_admin_token || parseBearer(req.headers['authorization']);
         if (!token) return res.status(401).json({ error: 'Unauthorized' });
-        const payload = jwt.verify(token, process.env.ADMIN_SECRET);
+        const payload = jwt.verify(token, adminSecret);
         if (payload.role !== 'admin') return res.status(401).json({ error: 'Unauthorized' });
         next();
     } catch (e) {
@@ -212,7 +231,7 @@ router.post('/verify', async (req, res) => {
             user_region: z.string().optional()
         });
         const { input, user_ign, user_region } = schema.parse(req.body); 
-        const adminSecret = process.env.ADMIN_SECRET || 'XP-2008';
+        const adminSecret = getAdminSecret();
         const clientIp = req.ip || req.connection.remoteAddress;
 
         if (!input) {
@@ -220,8 +239,8 @@ router.post('/verify', async (req, res) => {
         }
 
         // 1. Check Master Admin Secret (BYPASS ALL MIDDLEWARE)
-        if (input === adminSecret) {
-            const token = jwt.sign({ role: 'admin' }, process.env.ADMIN_SECRET || 'XP-2008', { expiresIn: '1d' });
+        if (adminSecret && input === adminSecret) {
+            const token = jwt.sign({ role: 'admin' }, adminSecret, { expiresIn: '1d' });
             res.cookie('xp_admin_token', token, {
                 httpOnly: true,
                 secure: process.env.NODE_ENV === 'production',
@@ -316,6 +335,9 @@ router.post('/verify', async (req, res) => {
                 const custom = typeof keyData.custom_results_json === 'string' ? JSON.parse(keyData.custom_results_json) : keyData.custom_results_json;
                 finalResults = { ...finalResults, ...custom };
             }
+            if (keyData.creator_advice) {
+                finalResults = { ...finalResults, advice: keyData.creator_advice };
+            }
 
             // Dispatch Vendor Webhook (10/10 Feature)
             await dispatchVendorWebhook(keyData.vendor_id, 'CODE_VERIFIED', {
@@ -337,12 +359,15 @@ router.post('/verify', async (req, res) => {
                 });
             }
 
+            const branding = normalizeBranding(keyData.brand_config);
+
             // HotCache Warmup
             HotCache.set(`verify_${input}`, {
                 type: 'user',
                 redirect: '/result.html',
                 results: finalResults,
-                branding: typeof keyData.brand_config === 'string' ? JSON.parse(keyData.brand_config) : keyData.brand_config,
+                branding,
+                advice: keyData.creator_advice || null,
                 message: 'CALIBRATION DATA RETRIEVED'
             });
 
@@ -350,7 +375,8 @@ router.post('/verify', async (req, res) => {
                 type: 'user',
                 redirect: '/result.html',
                 results: finalResults,
-                branding: typeof keyData.brand_config === 'string' ? JSON.parse(keyData.brand_config) : keyData.brand_config,
+                branding,
+                advice: keyData.creator_advice || null,
                 message: 'CALIBRATION DATA RETRIEVED'
             });
         }
@@ -368,19 +394,21 @@ router.post('/verify', async (req, res) => {
         } else if (e.message.includes('Table')) {
             errorMsg = 'DATABASE MIGRATION REQUIRED: Tables do not exist in the remote database.';
         } else {
-            errorMsg = \`VAULT SYSTEM ERROR: \${e.message}\`;
+            errorMsg = `VAULT SYSTEM ERROR: ${e.message}`;
         }
         res.status(500).json({ error: errorMsg });
     }
 });
 
-router.post('/admin/login', async (req, res) => {
+router.post('/admin/login', async (req, res, next) => {
     try {
+        const adminSecret = getAdminSecret();
+        if (!adminSecret) return res.status(503).json({ error: 'ADMIN_SECRET_NOT_CONFIGURED' });
         const schema = z.object({ password: z.string().min(4) });
         const { password } = schema.parse(req.body || {});
         if (!password) return res.status(400).json({ error: 'Missing password' });
-        if (password !== process.env.ADMIN_SECRET) return res.status(401).json({ error: 'Unauthorized' });
-        const token = jwt.sign({ role: 'admin' }, process.env.ADMIN_SECRET, { expiresIn: '1d' });
+        if (password !== adminSecret) return res.status(401).json({ error: 'Unauthorized' });
+        const token = jwt.sign({ role: 'admin' }, adminSecret, { expiresIn: '1d' });
         res.cookie('xp_admin_token', token, {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
@@ -445,7 +473,7 @@ router.get('/codes', authenticateVendor, async (req, res) => {
 });
 
 // POST /api/vault/generate
-router.post('/generate', authenticateVendor, async (req, res) => {
+router.post('/generate', authenticateVendor, async (req, res, next) => {
     try {
         const schema = z.object({
             results: z.record(z.any()).optional(),
@@ -491,17 +519,48 @@ router.put('/profile', authenticateVendor, async (req, res) => {
         const schema = z.object({
             brand_config: z.object({
                 vendor_id: z.string().optional(),
+                display_name: z.string().optional(),
                 logo: z.string().optional(),
+                logo_url: z.string().optional(),
                 colors: z.object({ primary: z.string().regex(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/) }).optional(),
-                socials: z.object({ yt: z.string().optional(), ig: z.string().optional() }).optional()
+                socials: z.object({
+                    yt: z.string().optional(),
+                    ig: z.string().optional(),
+                    tiktok: z.string().optional(),
+                    discord: z.string().optional()
+                }).optional(),
+                youtube: z.string().optional(),
+                tiktok: z.string().optional(),
+                discord: z.string().optional()
             }).optional(),
+            // Legacy flat payload support from vendor_dashboard.html
+            display_name: z.string().optional(),
+            logo_url: z.string().optional(),
+            youtube: z.string().optional(),
+            tiktok: z.string().optional(),
+            discord: z.string().optional(),
             webhook_url: z.string().url().nullable().optional()
         });
-        const { brand_config, webhook_url } = schema.parse(req.body);
+        const { brand_config, webhook_url, display_name, logo_url, youtube, tiktok, discord } = schema.parse(req.body);
         const vendorId = req.vendorId;
 
-        if (brand_config) {
-            await db.run('UPDATE vendors SET brand_config = ? WHERE vendor_id = ?', [JSON.stringify(brand_config), vendorId]);
+        let mergedBrandConfig = brand_config || null;
+        if (!mergedBrandConfig && (display_name || logo_url || youtube || tiktok || discord)) {
+            const current = await db.get('SELECT brand_config FROM vendors WHERE vendor_id = ?', [vendorId]);
+            const currentConfig = current?.brand_config
+                ? (typeof current.brand_config === 'string' ? JSON.parse(current.brand_config) : current.brand_config)
+                : {};
+            mergedBrandConfig = {
+                ...currentConfig,
+                display_name: display_name ?? currentConfig.display_name,
+                logo_url: logo_url ?? currentConfig.logo_url,
+                youtube: youtube ?? currentConfig.youtube,
+                tiktok: tiktok ?? currentConfig.tiktok,
+                discord: discord ?? currentConfig.discord
+            };
+        }
+        if (mergedBrandConfig) {
+            await db.run('UPDATE vendors SET brand_config = ? WHERE vendor_id = ?', [JSON.stringify(mergedBrandConfig), vendorId]);
         }
         if (webhook_url !== undefined) {
             await db.run('UPDATE vendors SET webhook_url = ? WHERE vendor_id = ?', [webhook_url, vendorId]);
@@ -639,7 +698,14 @@ router.post('/admin/vendors', authenticateAdmin, async (req, res) => {
         const { vendorId: requestedId, brandConfig } = schema.parse(req.body);
         
         // Generate Vendor ID if not provided, or clean up provided one
-        const vendorId = requestedId ? requestedId.toUpperCase().replace(/\s+/g, '-') : 'VNDR-' + Math.random().toString(36).substring(2, 7).toUpperCase();
+        const normalizedRequestedId = requestedId
+            ? requestedId.trim().toUpperCase().replace(/\s+/g, '-').replace(/[^A-Z0-9-]/g, '')
+            : '';
+        const vendorId = normalizedRequestedId || 'VNDR-' + Math.random().toString(36).substring(2, 7).toUpperCase();
+        if (vendorId.length < 2) return res.status(400).json({ error: 'INVALID_VENDOR_ID' });
+
+        const existing = await db.get('SELECT vendor_id FROM vendors WHERE vendor_id = ?', [vendorId]);
+        if (existing) return res.status(409).json({ error: 'VENDOR_ALREADY_EXISTS' });
 
         // Custom Access Key Format: XP-[VENDOR_ID]-[RANDOM_4_DIGITS]
         const randomDigits = Math.floor(1000 + Math.random() * 9000);
@@ -659,12 +725,13 @@ router.post('/admin/vendors', authenticateAdmin, async (req, res) => {
     } catch (e) {
         console.error('POST /admin/vendors error:', e);
         if (e instanceof z.ZodError) return res.status(400).json({ error: 'Invalid input' });
+        if (e && e.code === 'ER_DUP_ENTRY') return res.status(409).json({ error: 'VENDOR_ALREADY_EXISTS' });
         res.status(500).json({ error: 'Server error' });
     }
 });
 
 // POST /api/vault/admin/vendor/status
-router.post('/admin/vendor/status', authenticateAdmin, async (req, res) => {
+router.post('/admin/vendor/status', authenticateAdmin, async (req, res, next) => {
     try {
         const schema = z.object({
             vendorId: z.string().min(2),
@@ -722,6 +789,19 @@ router.delete('/admin/vendor/:vendorId', authenticateAdmin, async (req, res) => 
         res.json({ success: true, message: `VENDOR ${vendorId} DELETED PERMANENTLY` });
     } catch (e) {
         console.error('DELETE /admin/vendor error:', e);
+        res.status(500).json({ error: 'Server error' });
+    }
+});
+
+// Backward-compat alias for clients calling plural endpoint
+router.delete('/admin/vendors/:vendorId', authenticateAdmin, async (req, res) => {
+    try {
+        const { vendorId } = req.params;
+        await db.run('DELETE FROM sensitivity_keys WHERE vendor_id = ?', [vendorId]);
+        await db.run('DELETE FROM vendors WHERE vendor_id = ?', [vendorId]);
+        res.json({ success: true, message: `VENDOR ${vendorId} DELETED PERMANENTLY` });
+    } catch (e) {
+        console.error('DELETE /admin/vendors error:', e);
         res.status(500).json({ error: 'Server error' });
     }
 });
@@ -789,6 +869,47 @@ router.post('/track', async (req, res) => {
         res.json({ success: true });
     } catch (e) {
         res.status(500).json({ error: 'TRACK_ERR' });
+    }
+});
+
+router.get('/admin/live-feed', authenticateAdmin, async (req, res) => {
+    try {
+        const rows = await db.all(`
+            SELECT ca.used_at as ts, ca.user_ign, ca.user_region, ca.feedback_rating, ca.feedback_comment,
+                   sk.vendor_id
+            FROM code_activity ca
+            LEFT JOIN sensitivity_keys sk ON sk.lookup_key = ca.lookup_key
+            ORDER BY ca.used_at DESC
+            LIMIT 30
+        `);
+        const events = rows.map(r => ({
+            type: r.feedback_rating ? 'feedback' : 'verify',
+            timestamp: r.ts,
+            vendor_id: r.vendor_id || 'XP-CORE',
+            user_ign: r.user_ign || 'Anonymous',
+            region: r.user_region || 'Unknown',
+            rating: r.feedback_rating || null,
+            feedback: r.feedback_comment || null
+        }));
+        res.json(events);
+    } catch (e) {
+        console.error('LIVE_FEED_ERR:', e);
+        res.status(500).json({ error: 'LIVE_FEED_UNAVAILABLE' });
+    }
+});
+
+router.get('/admin/security-logs', authenticateAdmin, async (req, res) => {
+    try {
+        const logs = await db.all(`
+            SELECT id, ip_address, event_type, details, created_at
+            FROM security_logs
+            ORDER BY created_at DESC
+            LIMIT 100
+        `);
+        res.json(logs);
+    } catch (e) {
+        console.error('SECURITY_LOGS_ERR:', e);
+        res.status(500).json({ error: 'SECURITY_LOGS_UNAVAILABLE' });
     }
 });
 
@@ -904,19 +1025,28 @@ router.put('/code/:entryCode/deactivate', authenticateVendor, async (req, res) =
 });
 router.get('/vendor/profile', authenticateVendor, async (req, res) => {
     try {
-        const vendor = await db.get('SELECT vendor_id, status, active_until FROM vendors WHERE vendor_id = ?', [req.vendorId]);
+        const vendor = await db.get('SELECT vendor_id, status, active_until, brand_config, webhook_url FROM vendors WHERE vendor_id = ?', [req.vendorId]);
         const stats = await db.get(`
             SELECT COUNT(*) as codes, SUM(current_usage) as hits
             FROM sensitivity_keys 
             WHERE vendor_id = ?
         `, [req.vendorId]);
+        const config = vendor?.brand_config
+            ? (typeof vendor.brand_config === 'string' ? JSON.parse(vendor.brand_config) : vendor.brand_config)
+            : {};
         
         res.json({
             vendor_id: vendor.vendor_id,
             status: vendor.status,
             active_until: vendor.active_until,
             total_codes: stats.codes || 0,
-            total_hits: stats.hits || 0
+            total_hits: stats.hits || 0,
+            display_name: config.display_name || '',
+            logo_url: config.logo_url || config.logo || '',
+            youtube: config.youtube || config?.socials?.yt || '',
+            tiktok: config.tiktok || config?.socials?.tiktok || '',
+            discord: config.discord || config?.socials?.discord || '',
+            webhook_url: vendor.webhook_url || ''
         });
     } catch (e) {
         res.status(500).json({ error: 'Server error' });

--- a/server.js
+++ b/server.js
@@ -77,16 +77,19 @@ app.use('/api/vault/admin', adminLimiter);
 // Server configuration
 const http = require('http');
 const server = http.createServer(app);
-const { Server } = require('socket.io');
-const io = new Server(server, {
-    cors: { origin: "*" }
-});
-
-// Real-time integration
+let io = null;
+if (!process.env.VERCEL) {
+    const { Server } = require('socket.io');
+    io = new Server(server, {
+        cors: { origin: "*" }
+    });
+    io.on('connection', (socket) => {
+        console.log('⚡ SOCKET_CONNECTED:', socket.id);
+    });
+} else {
+    console.log('ℹ️ VERCEL_ENV_DETECTED: live feed will use polling endpoints.');
+}
 app.set('io', io);
-io.on('connection', (socket) => {
-    console.log('⚡ SOCKET_CONNECTED:', socket.id);
-});
 
 // Routes
 const vaultRoutes = require('./routes/vaultRoutes');

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+process.env.ADMIN_SECRET = process.env.ADMIN_SECRET || 'TEST-ADMIN-SECRET';
 const app = require('../server');
 
 describe('API', () => {

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+process.env.ADMIN_SECRET = process.env.ADMIN_SECRET || 'TEST-ADMIN-SECRET';
 const app = require('../server');
 
 describe('Smoke', () => {
@@ -11,7 +12,7 @@ describe('Smoke', () => {
   it('admin verify with master code', async () => {
     const res = await request(app)
       .post('/api/vault/verify')
-      .send({ input: process.env.ADMIN_SECRET || 'XP-2008' });
+      .send({ input: process.env.ADMIN_SECRET });
     expect(res.status).toBe(200);
     expect(res.body.type).toBe('admin');
     expect(res.body.redirect).toBe('/admin.html');

--- a/vault.sql
+++ b/vault.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS vendors (
     access_key VARCHAR(100) UNIQUE NOT NULL, -- bcrypt hash
     lookup_key VARCHAR(20) UNIQUE DEFAULT NULL,
     active_until DATETIME DEFAULT NULL,
+    webhook_url VARCHAR(500) DEFAULT NULL,
     brand_config JSON NOT NULL, -- { "logo": "...", "colors": { "primary": "..." }, "socials": { "yt": "...", "ig": "...", "dc": "..." } }
     status ENUM('active', 'suspended') DEFAULT 'active',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -31,6 +32,7 @@ CREATE TABLE IF NOT EXISTS sensitivity_keys (
     lookup_key VARCHAR(16) UNIQUE NOT NULL,
     vendor_id VARCHAR(50),
     results_json JSON NOT NULL, -- Calculated sensitivity data
+    creator_advice TEXT DEFAULT NULL,
     custom_results_json JSON DEFAULT NULL, -- Manual overrides by vendor/user
     usage_limit INT DEFAULT NULL, -- NULL = Unlimited
     current_usage INT DEFAULT 0,
@@ -90,8 +92,8 @@ CREATE TABLE IF NOT EXISTS security_logs (
 -- Seed Data
 INSERT IGNORE INTO organizations (org_id, org_name) VALUES ('XP-CORE-ORG', 'XP ARENA GLOBAL');
 
-INSERT IGNORE INTO vendors (org_id, vendor_id, access_key, lookup_key, brand_config, status) VALUES 
-('XP-CORE-ORG', 'XP-ADMIN', 'XP-2008', NULL, '{"logo": "", "colors": {"primary": "#00f2fe"}, "socials": {}}', 'active');
+-- NOTE: XP-ADMIN seed should be provisioned from environment secret by migrate.js
+-- (ADMIN_SECRET / SEED_VENDOR_KEY) to avoid hardcoded credentials in SQL.
 
 -- System Settings Table
 CREATE TABLE IF NOT EXISTS system_settings (


### PR DESCRIPTION
### Motivation
- Replace single-file SQLite with a pooled MySQL/TiDB setup for cloud deployments and multi-tenant scaling.
- Remove hardcoded admin credentials, add secure seeding from environment secrets, and expand vendor/webhook/analytics capabilities. 
- Improve frontend admin/vendor UX (live feed, security logs, vendor webhooks, i18n hooks) and PWA/service-worker behavior for deployments.

### Description
- Environment and DB: updated `.env.example`/`.env.template` for MySQL/TiDB variables and removed hardcoded secrets; migrated schema in `vault.sql` / `FINAL_PRODUCTION_DB_SETUP.sql` to add `webhook_url` and `creator_advice` and removed seeded plaintext admin access. 
- Migrations and DB helper: rewrote `migrate.js` to be idempotent, create/USE database, conditionally seed or rotate `XP-ADMIN` using `ADMIN_SECRET`/`SEED_VENDOR_KEY`, and add schema alignment ALTERs; updated `db.js` to use `mysql2` pool, improved error messages and skip diagnostic ping during tests. 
- API & auth: refactored admin/vendor auth in `routes/vaultRoutes.js` to derive secrets through `getAdminSecret()`, enforce admin secret presence, normalize branding payloads, add webhook dispatch `dispatchVendorWebhook`, and add admin endpoints `GET /admin/live-feed` and `GET /admin/security-logs`; added backward-compatible route alias for vendor deletion. 
- Frontend & UX: multiple UI improvements across `public/*` including admin live feed polling and security logs, vendor dashboard webhook field and profile PUT changes, result page sharing/clipboard behavior, PWA install tips, RAM heuristics, translations hook (`xp:language-change`), and many small UX/translation refinements. 
- Service worker & assets: bumped cache name to `xp-arena-v2`, added `skipWaiting`/`clients.claim`, network-first for documents and stale-while-revalidate for static assets. 
- Misc: switched `eslint.config.js` to CommonJS export, enhanced `lib/calculator.js` to apply `global_sensitivity_offset` to computed results and manual overrides, and updated generate/verify flows to include branding/advice in hot cache. 

### Testing
- Ran automated test suite with `jest`/`npm test` (includes `tests/api.test.js` and `tests/smoke.test.js`) after setting `ADMIN_SECRET` in the test env, and all tests passed. 
- Local smoke tests exercised main pages (`GET /`), health endpoint, and admin verify via master code and succeeded. 
- Migration script exercised on a dev MySQL instance to validate idempotent schema alignment and seed logic (logged success during run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bad25391fc8324aaa4d86878e3b262)