### PR TITLE
Revamp admin/verify/result UX and fix admin unlock + toast alignment

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -535,7 +535,6 @@
   <script src="devices.js?v=3"></script>
   <script src="translations.js"></script>
   <script src="notifications.js"></script>
-  <script src="theme-manager.js"></script>
   <script src="settings.js"></script>
   <script>
     // ═══════════════════════════════════════════════════════════════
@@ -576,11 +575,9 @@
         btn.disabled = true;
         status.textContent = 'CONNECTING...';
 
-        const res = await fetch('/api/vault/admin/login', {
+        const res = await NexusAuth.fetch('/api/vault/admin/login', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ password: pass }),
-          credentials: 'include'
+          body: JSON.stringify({ password: pass })
         });
         let payload = {};
         try { payload = await res.json(); } catch(_) {}
@@ -1056,17 +1053,15 @@
         if (e.key === 'Enter') checkPass();
       });
 
-      // Auto-unlock if session is active
-      if (NexusAuth.isAuthenticated()) {
-        api('/api/vault/admin/stats').then(data => {
-          if (data) unlockAdminPanel();
-          else document.getElementById('privateGate').classList.remove('hidden');
-        }).catch(() => {
-          document.getElementById('privateGate').classList.remove('hidden');
-        });
-      } else {
+      // Auto-unlock if session/cookie/token is active
+      const cachedToken = sessionStorage.getItem('axp_token') || localStorage.getItem('axp_token');
+      if (cachedToken) NexusAuth.setToken(cachedToken);
+      api('/api/vault/admin/stats').then(data => {
+        if (data) unlockAdminPanel();
+        else document.getElementById('privateGate').classList.remove('hidden');
+      }).catch(() => {
         document.getElementById('privateGate').classList.remove('hidden');
-      }
+      });
     });
   </script>
 </body>

--- a/public/notifications.js
+++ b/public/notifications.js
@@ -48,7 +48,10 @@ window.notify = function(message, type = 'info', duration = 4000) {
         box-shadow: 0 20px 50px rgba(0,0,0,0.6), inset 0 0 20px ${color}11;
         pointer-events: auto;
         animation: toastEntrance 0.6s cubic-bezier(0.2, 1, 0.3, 1) both;
-        position: relative;
+        position: relative !important;
+        left: auto !important;
+        top: auto !important;
+        transform: none !important;
         overflow: hidden;
         display: flex;
         flex-direction: column;

--- a/public/result.html
+++ b/public/result.html
@@ -188,7 +188,7 @@
     .stats-hub {
       padding: 1.5rem;
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 1rem;
     }
     .stat-module {
@@ -277,8 +277,11 @@
       width: 800px;
     }
 
+    @media (max-width: 720px) {
+      .stats-hub { grid-template-columns: 1fr 1fr; }
+    }
     @media (max-width: 420px) {
-      .stats-hub { grid-template-columns: 1fr; }
+      .stats-hub { grid-template-columns: 1fr; gap: 0.75rem; }
       .device-info-main .model { font-size: 1.2rem; }
     }
   </style>
@@ -328,7 +331,7 @@
         <div class="card-meta-top">
           <div class="brand-id">
             <div class="brand-logo-frame">
-              <img id="creatorLogo" src="favicon.png" alt="Creator logo">
+              <img id="creatorLogo" src="favicon.svg" alt="Creator logo">
             </div>
             <div class="brand-text">
               <div class="primary">AXP_HUB</div>
@@ -348,7 +351,7 @@
           <div class="device-header" data-i18n="deviceAccess">Hardware Identification</div>
           <div class="device-identity">
             <div class="device-preview-frame">
-              <img id="devicePreview" src="favicon.png" alt="Device preview">
+              <img id="devicePreview" src="favicon.svg" alt="Device preview">
             </div>
             <div class="device-info-main">
               <div class="section-eyebrow">UNIT_MODEL</div>
@@ -382,20 +385,44 @@
           </div>
           <div class="stat-module">
             <div class="glyph" id="signalRed">↑</div>
-            <div class="label">Red_Dot / 2x / 4x</div>
-            <div class="value" style="font-size: 1.1rem; line-height: 1.5;"><span id="idRedDot">--</span> / <span id="id2x">--</span> / <span id="id4x">--</span></div>
+            <div class="label">Red_Dot</div>
+            <div class="value" id="idRedDot">--</div>
+            <div class="trend">DYNAMIC_SCALING</div>
+          </div>
+          <div class="stat-module">
+            <div class="glyph">↑</div>
+            <div class="label">2x_Scope</div>
+            <div class="value" id="id2x">--</div>
+            <div class="trend">DYNAMIC_SCALING</div>
+          </div>
+          <div class="stat-module">
+            <div class="glyph">↑</div>
+            <div class="label">4x_Scope</div>
+            <div class="value" id="id4x">--</div>
             <div class="trend">DYNAMIC_SCALING</div>
           </div>
           <div class="stat-module">
             <div class="glyph" id="signalScope">↘</div>
-            <div class="label">Sniper / Free_Look</div>
-            <div class="value" style="font-size: 1.1rem; line-height: 1.5;"><span id="idSniper">--</span> / <span id="idFreeLook">--</span></div>
+            <div class="label">Sniper</div>
+            <div class="value" id="idSniper">--</div>
             <div class="trend">PRECISION_STABLE</div>
           </div>
           <div class="stat-module">
+            <div class="glyph">↗</div>
+            <div class="label">Free_Look</div>
+            <div class="value" id="idFreeLook">--</div>
+            <div class="trend">VISION_CONTROL</div>
+          </div>
+          <div class="stat-module">
             <div class="glyph">◎</div>
-            <div class="label">DPI / Fire_Btn</div>
-            <div class="value" style="font-size: 1.1rem; line-height: 1.5;"><span id="idDPI">--</span> / <span id="idFireButton">--</span></div>
+            <div class="label">DPI</div>
+            <div class="value" id="idDPI">--</div>
+            <div class="trend">INPUT_POLYGON</div>
+          </div>
+          <div class="stat-module">
+            <div class="glyph">✦</div>
+            <div class="label">Fire_Btn</div>
+            <div class="value" id="idFireButton">--</div>
             <div class="trend">INPUT_POLYGON</div>
           </div>
         </div>
@@ -403,7 +430,7 @@
         <!-- Advisor Section -->
         <div class="advisor-zone">
           <div class="advisor-avatar-frame">
-            <img id="notesAvatar" src="favicon.png" alt="Creator avatar">
+            <img id="notesAvatar" src="favicon.svg" alt="Creator avatar">
           </div>
           <div class="advisor-text">
             <div class="label">OPERATOR_ADVICE</div>
@@ -459,7 +486,7 @@
       <div style="display:flex; justify-content:space-between; margin-bottom: 40px;">
         <div style="display:flex; align-items:center; gap:20px;">
           <div style="width:80px; height:80px; background:#fff; border-radius:20px; padding:8px; display:flex; align-items:center; justify-content:center;">
-            <img id="shareLogo" src="favicon.png" style="width:100%; height:100%; object-fit:contain;">
+            <img id="shareLogo" src="favicon.svg" style="width:100%; height:100%; object-fit:contain;">
           </div>
           <div>
             <div style="font-size: 2.2rem; font-weight: 800; color:#fff; letter-spacing:0.1em;">AXP_HUB</div>
@@ -477,7 +504,7 @@
       </div>
       <div style="background:rgba(255,255,255,0.05); border:1px solid rgba(255,255,255,0.1); border-radius:30px; padding:30px; margin-bottom:30px; display:flex; align-items:center; gap:30px;">
         <div style="width:120px; height:120px; background:#fff; border-radius:24px; padding:10px; display:flex; align-items:center; justify-content:center;">
-          <img id="shareDevicePreview" src="favicon.png" style="width:100%; height:100%; object-fit:contain;">
+          <img id="shareDevicePreview" src="favicon.svg" style="width:100%; height:100%; object-fit:contain;">
         </div>
         <div>
           <div style="font-size:0.9rem; color:#94a3b8; letter-spacing:0.2em; margin-bottom:8px;">UNIT_MODEL</div>
@@ -492,30 +519,50 @@
         </div>
         <div style="background:rgba(0,0,0,0.2); color:#000; padding:8px 20px; border-radius:50px; font-size:0.9rem; font-weight:900;" data-i18n="syncedProfile">SYNCED_PROFILE</div>
       </div>
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:20px; margin-bottom:30px;">
+      <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:20px; margin-bottom:30px;">
         <div style="background:rgba(255,255,255,0.03); border:1px solid rgba(255,255,255,0.08); border-radius:25px; padding:25px; position:relative;">
           <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">GENERAL_SENS</div>
           <div id="shareGeneral" style="font-size:3rem; font-weight:800; color:#fff;">--</div>
           <div style="position:absolute; top:25px; right:25px; font-size:2rem; color:#a855f7;">↑</div>
         </div>
         <div style="background:rgba(255,255,255,0.03); border:1px solid rgba(255,255,255,0.08); border-radius:25px; padding:25px; position:relative;">
-          <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">RED_DOT \ 2X \ 4X</div>
-          <div style="font-size:2rem; font-weight:800; color:#fff;"><span id="shareRedDot">--</span> \ <span id="share2x">--</span> \ <span id="share4x">--</span></div>
+          <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">RED_DOT</div>
+          <div style="font-size:2rem; font-weight:800; color:#fff;"><span id="shareRedDot">--</span></div>
           <div style="position:absolute; top:25px; right:25px; font-size:2rem; color:#a855f7;">↑</div>
         </div>
         <div style="background:rgba(255,255,255,0.03); border:1px solid rgba(255,255,255,0.08); border-radius:25px; padding:25px; position:relative;">
-          <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">SNIPER \ FREE_LOOK</div>
-          <div style="font-size:2rem; font-weight:800; color:#fff;"><span id="shareSniper">--</span> \ <span id="shareFreeLook">--</span></div>
+          <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">2X_SCOPE</div>
+          <div style="font-size:2rem; font-weight:800; color:#fff;"><span id="share2x">--</span></div>
+          <div style="position:absolute; top:25px; right:25px; font-size:2rem; color:#a855f7;">↑</div>
+        </div>
+        <div style="background:rgba(255,255,255,0.03); border:1px solid rgba(255,255,255,0.08); border-radius:25px; padding:25px; position:relative;">
+          <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">4X_SCOPE</div>
+          <div style="font-size:2rem; font-weight:800; color:#fff;"><span id="share4x">--</span></div>
+          <div style="position:absolute; top:25px; right:25px; font-size:2rem; color:#a855f7;">↑</div>
+        </div>
+        <div style="background:rgba(255,255,255,0.03); border:1px solid rgba(255,255,255,0.08); border-radius:25px; padding:25px; position:relative;">
+          <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">SNIPER</div>
+          <div style="font-size:2rem; font-weight:800; color:#fff;"><span id="shareSniper">--</span></div>
           <div style="position:absolute; top:25px; right:25px; font-size:2rem; color:#a855f7;">↘</div>
         </div>
         <div style="background:rgba(255,255,255,0.03); border:1px solid rgba(255,255,255,0.08); border-radius:25px; padding:25px; position:relative;">
-          <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">DPI \ FIRE BUTTON</div>
-          <div style="font-size:2rem; font-weight:800; color:#fff;"><span id="shareDpi">--</span> \ <span id="shareFireButton">--</span></div>
+          <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">FREE_LOOK</div>
+          <div style="font-size:2rem; font-weight:800; color:#fff;"><span id="shareFreeLook">--</span></div>
+          <div style="position:absolute; top:25px; right:25px; font-size:2rem; color:#a855f7;">↗</div>
+        </div>
+        <div style="background:rgba(255,255,255,0.03); border:1px solid rgba(255,255,255,0.08); border-radius:25px; padding:25px; position:relative;">
+          <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">DPI</div>
+          <div style="font-size:2rem; font-weight:800; color:#fff;"><span id="shareDpi">--</span></div>
           <div style="position:absolute; top:25px; right:25px; font-size:2rem; color:#a855f7;">◎</div>
+        </div>
+        <div style="background:rgba(255,255,255,0.03); border:1px solid rgba(255,255,255,0.08); border-radius:25px; padding:25px; position:relative;">
+          <div style="font-size:1rem; color:#94a3b8; margin-bottom:10px;">FIRE_BUTTON</div>
+          <div style="font-size:2rem; font-weight:800; color:#fff;"><span id="shareFireButton">--</span></div>
+          <div style="position:absolute; top:25px; right:25px; font-size:2rem; color:#a855f7;">✦</div>
         </div>
       </div>
       <div style="background:rgba(255,255,255,0.03); border-radius:25px; padding:25px; display:flex; align-items:center; gap:20px;">
-        <img id="shareFooterLogo" src="favicon.png" style="width:70px; height:70px; border-radius:15px; background:#fff;">
+        <img id="shareFooterLogo" src="favicon.svg" style="width:70px; height:70px; border-radius:15px; background:#fff;">
         <div style="flex:1;">
           <div style="font-size:0.8rem; color:#94a3b8; margin-bottom:4px;">OPERATOR_ADVICE</div>
           <div id="shareAdvice" style="font-size:1.2rem; font-weight:800; color:#fff;">NO_EXTRA_ADVICE_PROVIDED</div>
@@ -529,7 +576,6 @@
   <script src="nexus-auth.js"></script>
   <script src="translations.js"></script>
   <script src="notifications.js"></script>
-  <script src="theme-manager.js"></script>
   <script src="result-utils.js"></script>
   <script src="settings.js"></script>
   <script src="update-overlay.js"></script>

--- a/public/result.js
+++ b/public/result.js
@@ -1,4 +1,5 @@
 (function () {
+    const AXP_LOGO = 'favicon.svg';
     const Utils = window.ResultUtils || {};
     const clamp = Utils.clamp || ((num, min, max) => Math.max(min, Math.min(max, num)));
     const parseRange = Utils.parseRange || ((value) => {
@@ -265,7 +266,7 @@
     function buildCardDetails({ branding, hydrated, modelText, displayName, code, results }) {
         const formattedCode = formatAccessCode(hydrated.vendorId, code);
         return {
-            logo: branding.logo_url || branding.logo || 'favicon.png',
+            logo: AXP_LOGO,
             expiry: hydrated.validUntil ? document.getElementById('expiryValue').textContent : 'NEVER',
             efficiency: currentEfficiency,
             model: modelText,
@@ -551,9 +552,9 @@
         document.getElementById('creatorAdvice').textContent = hydrated.advice || 'OPTIMIZED FOR COMPETITIVE PLAY';
         document.getElementById('chipVendor').textContent = displayName.toUpperCase();
         document.getElementById('chipStatus').textContent = hydrated.validUntil ? t('activeTimed', 'ACTIVE / TIMED') : t('activeOpen', 'ACTIVE / OPEN');
-        document.getElementById('devicePreview').src = branding.logo_url || branding.logo || 'favicon.png';
-        document.getElementById('notesAvatar').src = branding.logo_url || branding.logo || 'favicon.png';
-        if (branding.logo_url || branding.logo) document.getElementById('creatorLogo').src = branding.logo_url || branding.logo;
+        document.getElementById('devicePreview').src = AXP_LOGO;
+        document.getElementById('notesAvatar').src = AXP_LOGO;
+        document.getElementById('creatorLogo').src = AXP_LOGO;
         currentAdvice = hydrated.advice || '';
         updateAdviceCopy(hydrated.advice);
         updateShareHint();

--- a/public/settings.js
+++ b/public/settings.js
@@ -348,7 +348,7 @@
     style.textContent = `
         #settings-hub {
             position: fixed;
-            bottom: var(--hub-bottom, 90px);
+            bottom: var(--hub-bottom, 132px);
             right: 1.5rem;
             z-index: 10000;
             display: flex;
@@ -391,12 +391,17 @@
             cursor: pointer;
             box-shadow: 0 0 15px var(--accent-primary-glow);
             transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.35s ease, background 0.35s ease;
+            animation: hubTriggerFloat 5.5s ease-in-out infinite;
         }
         .hub-trigger svg { width: 22px; height: 22px; transition: transform 0.8s cubic-bezier(0.22, 1, 0.36, 1); animation: hubGearSpin 9s linear infinite; }
         .hub-trigger:hover { transform: translateY(-2px) scale(1.06); }
         .hub-trigger.active { transform: translate(-8px, -4px) scale(1.04); }
         .hub-trigger.active svg { transform: rotate(180deg) scale(1.05); animation-play-state: paused; }
         @keyframes hubGearSpin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        @keyframes hubTriggerFloat {
+            0%, 100% { transform: translateY(0) rotate(0deg); }
+            50% { transform: translateY(-6px) rotate(8deg); }
+        }
         
         .hub-panel {
             width: 260px;

--- a/public/verify.html
+++ b/public/verify.html
@@ -17,8 +17,8 @@
     }
 
     .hologram-stage {
-      width: 140px;
-      height: 140px;
+      width: 172px;
+      height: 172px;
       margin: 0 auto 2.5rem;
       position: relative;
       display: flex;
@@ -39,8 +39,11 @@
     }
     .hologram-cube::before {
       content: '🛡';
-      font-size: 2.5rem;
-      filter: drop-shadow(0 0 10px var(--gold-glow));
+      width: 92px;
+      height: 92px;
+      background: url('favicon.svg') center / contain no-repeat;
+      filter: drop-shadow(0 0 16px var(--gold-glow));
+      font-size: 0;
       animation: iconFloat 4s ease-in-out infinite;
     }
 
@@ -71,7 +74,7 @@
       0% { top: -10px; opacity: 0; } 
       10% { opacity: 1; } 
       90% { opacity: 1; } 
-      100% { top: 150px; opacity: 0; } 
+      100% { top: 182px; opacity: 0; } 
     }
 
     .result-panel {


### PR DESCRIPTION
### Motivation
- Improve the admin access flow and fix the reported “button not taking me to admin features” failure by making the login flow use the same auth helper used elsewhere.
- Remove the duplicate floating settings control and make the remaining settings hub feel like a single, polished floating control.\
- Refresh the `verify.html` scanner visual to use the AXP logo and a larger hologram stage for stronger branding.\
- Clarify the `result.html` metrics so each sensitivity value is presented in its own card, improve mobile layout, and ensure exported/share cards and in-page images use the AXP logo.\

### Description
- Use `NexusAuth.fetch` for admin login and add token restoration from `sessionStorage`/`localStorage` to auto-unlock the admin panel via `/api/vault/admin/stats` (changes in `public/admin.html`).
- Remove the injected duplicate FAB by dropping `theme-manager.js` on admin pages and adjust settings hub behavior/placement and animation in `public/settings.js` to float higher and add a subtle rotation float.\
- Replace the small shield in `public/verify.html` with a larger rotating frame that uses `favicon.svg`, enlarge the hologram stage, and tweak its animations for better presence.\
- Split combined metric displays into separate stat cards on `public/result.html`, update the export/share capture layout to match, and standardize image sources to `favicon.svg` by adding `AXP_LOGO` usage in `public/result.js`.\
- Fix toast alignment/responsiveness by overriding inherited fixed positioning on the created `.xp-toast` elements in `public/notifications.js` so toasts appear centered in the top container on mobile and desktop.\

### Testing
- Ran the unit suites with `npm test -- --runInBand tests/result_template.test.js tests/admin_uplink.test.js` and both suites passed.\
- Test result: `PASS tests/admin_uplink.test.js` and `PASS tests/result_template.test.js` (2 suites, 6 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df38b16bc08324a011280a03e36eb4)