### PR TITLE
Fix admin authentication bootstrap in admin portal

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -576,6 +576,11 @@
     let dashboardPoller = null;
     let allVendorsCache = [];
     let selectedTier = 'normal';
+    const ADMIN_TOKEN_KEY = 'axp_admin_token';
+
+    if (window.NexusAuth) {
+      NexusAuth.TOKEN_KEY = ADMIN_TOKEN_KEY;
+    }
 
     // ── API Helper ─────────────────────────────────────────────────
     async function api(path, method = 'GET', body = null) {
@@ -1082,14 +1087,17 @@
 
     // ── Boot ──────────────────────────────────────────────────────
     document.addEventListener('DOMContentLoaded', () => {
+      if (window.NexusAuth) {
+        NexusAuth.TOKEN_KEY = ADMIN_TOKEN_KEY;
+      }
       document.getElementById('adminPass').addEventListener('keydown', e => {
         if (e.key === 'Enter') checkPass();
       });
 
       // Auto-unlock if session/cookie/token is active
-      const cachedToken = sessionStorage.getItem('axp_token') || localStorage.getItem('axp_token');
+      const cachedToken = sessionStorage.getItem(ADMIN_TOKEN_KEY) || localStorage.getItem(ADMIN_TOKEN_KEY);
       if (cachedToken) NexusAuth.setToken(cachedToken);
-      fetch('/api/vault/admin/stats', { credentials: 'include' })
+      NexusAuth.fetch('/api/vault/admin/stats')
         .then(r => r.ok ? r.json() : null)
         .then(data => {
           if (data) unlockAdminPanel();


### PR DESCRIPTION
### Motivation
- The admin UI was inheriting the vendor token key and using a raw `fetch` for its session probe which can miss bearer-token authorization and cause admin sessions to not auto-unlock. 
- Prevent token cross-contamination between vendor and admin flows by storing admin tokens under a dedicated key. 
- Also note that missing DB env vars or an IP whitelist can prevent admin access even when UI logic is correct.

### Description
- Set a dedicated admin token key `axp_admin_token` in `public/admin.html` and assign it to `NexusAuth.TOKEN_KEY` so the admin UI uses its own storage key. 
- Align startup token restore to read/write the same `axp_admin_token` from `sessionStorage`/`localStorage`. 
- Replace the raw initial `fetch('/api/vault/admin/stats')` probe with `NexusAuth.fetch('/api/vault/admin/stats')` to ensure bearer auth headers and consistent credential handling. 
- Changes are limited to `public/admin.html` and only affect admin auth/bootstrap behavior.

### Testing
- Ran lint with `npm run lint` and it completed successfully. 
- Ran the full Jest suite with `npm test -- --runInBand` and all test suites passed (`12` suites, `30` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9b9214ec832daca44db339f72b8b)