### PR TITLE
Require manual admin unlock and isolate admin auth token

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -576,6 +576,9 @@
     let dashboardPoller = null;
     let allVendorsCache = [];
     let selectedTier = 'normal';
+    const ADMIN_TOKEN_KEY = 'axp_admin_token';
+
+    if (window.NexusAuth) NexusAuth.TOKEN_KEY = ADMIN_TOKEN_KEY;
 
     // ── API Helper ─────────────────────────────────────────────────
     async function api(path, method = 'GET', body = null) {
@@ -1086,18 +1089,9 @@
         if (e.key === 'Enter') checkPass();
       });
 
-      // Auto-unlock if session/cookie/token is active
-      const cachedToken = sessionStorage.getItem('axp_token') || localStorage.getItem('axp_token');
-      if (cachedToken) NexusAuth.setToken(cachedToken);
-      fetch('/api/vault/admin/stats', { credentials: 'include' })
-        .then(r => r.ok ? r.json() : null)
-        .then(data => {
-          if (data) unlockAdminPanel();
-          else document.getElementById('privateGate').classList.remove('hidden');
-        })
-        .catch(() => {
-          document.getElementById('privateGate').classList.remove('hidden');
-        });
+      // Enforce manual gate every time (no silent auto-unlock path).
+      // This keeps admin access behind explicit secret entry even if a cookie/token exists.
+      document.getElementById('privateGate').classList.remove('hidden');
     });
   </script>
 </body>


### PR DESCRIPTION
### Motivation

- Prevent the admin panel from being silently unlocked via an existing user/session token to harden access control.
- Keep admin credentials separate from regular user credentials by using a distinct token storage key.

### Description

- Added `ADMIN_TOKEN_KEY = 'axp_admin_token'` and, if available, assign it to `NexusAuth.TOKEN_KEY` to isolate admin auth storage.
- Removed the previous auto-unlock flow that read `axp_token` from `sessionStorage`/`localStorage` and probed `/api/vault/admin/stats`.
- Always reveal the admin gate (`privateGate`) on boot to enforce explicit secret entry for admin access.
- Changes applied to `public/admin.html` (script block handling auth/boot logic).

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9b9214ec832daca44db339f72b8b)