### PR TITLE
Admin UI & Portal tweaks: auto-open admin panel, lab link, and UI button styles

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -239,7 +239,7 @@
 <body class="page-admin">
 
   <!-- ══════════════════ VAULT GATE ══════════════════ -->
-  <div id="privateGate" class="vault-gate">
+  <div id="privateGate" class="vault-gate hidden">
     <div class="vault-card">
       <div class="vault-brand-mark"><img src="favicon.svg" alt="AXP"></div>
       <div class="badge-gold mb-2">SYSTEM_OVERRIDE_V6</div>
@@ -254,7 +254,7 @@
   </div>
 
   <!-- ══════════════════ MAIN PANEL ══════════════════ -->
-  <div id="mainPanel" class="hidden">
+  <div id="mainPanel">
 
     <header class="page-header">
       <div class="ph-logo" style="color: var(--gold);">AXP_MASTER</div>
@@ -576,6 +576,9 @@
     let dashboardPoller = null;
     let allVendorsCache = [];
     let selectedTier = 'normal';
+    const ADMIN_TOKEN_KEY = 'axp_admin_token';
+
+    if (window.NexusAuth) NexusAuth.TOKEN_KEY = ADMIN_TOKEN_KEY;
 
     // ── API Helper ─────────────────────────────────────────────────
     async function api(path, method = 'GET', body = null) {
@@ -1082,22 +1085,9 @@
 
     // ── Boot ──────────────────────────────────────────────────────
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('adminPass').addEventListener('keydown', e => {
-        if (e.key === 'Enter') checkPass();
-      });
-
-      // Auto-unlock if session/cookie/token is active
-      const cachedToken = sessionStorage.getItem('axp_token') || localStorage.getItem('axp_token');
-      if (cachedToken) NexusAuth.setToken(cachedToken);
-      fetch('/api/vault/admin/stats', { credentials: 'include' })
-        .then(r => r.ok ? r.json() : null)
-        .then(data => {
-          if (data) unlockAdminPanel();
-          else document.getElementById('privateGate').classList.remove('hidden');
-        })
-        .catch(() => {
-          document.getElementById('privateGate').classList.remove('hidden');
-        });
+      // Admin access is granted from index.html gate; admin page opens directly.
+      // If session/token is missing, first API call will return 401 and redirect to index.
+      unlockAdminPanel();
     });
   </script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -451,6 +451,7 @@
     <div class="portal-logo">AXP_CORE</div>
     <div class="portal-top-links">
       <a href="stats.html" class="portal-top-link">Global</a>
+      <a href="lab.html" class="portal-top-link">Lab</a>
       <a href="generator.html" class="portal-top-link">Demo</a>
     </div>
   </header>
@@ -501,9 +502,9 @@
 
       <div class="vault-or">OR</div>
 
-      <a href="generator.html" class="vault-demo-link">
+      <a href="lab.html" class="vault-demo-link">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-        Try free demo — no code needed
+        Open AXP Lab — free practice mode
       </a>
     </div>
 

--- a/public/result.html
+++ b/public/result.html
@@ -184,6 +184,24 @@
       align-items: center;
       gap: 10px;
     }
+    .code-copy-btn {
+      min-width: 42px;
+      min-height: 42px;
+      border-radius: 12px;
+      border: 1px solid rgba(168, 85, 247, 0.42);
+      background: linear-gradient(145deg, rgba(168, 85, 247, 0.2), rgba(0, 229, 255, 0.08));
+      color: var(--tx-hero);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 10px 26px rgba(0, 0, 0, 0.35);
+      transition: transform 0.2s var(--ease), box-shadow 0.2s var(--ease), border-color 0.2s;
+    }
+    .code-copy-btn:hover {
+      transform: translateY(-1px);
+      border-color: rgba(0, 229, 255, 0.48);
+      box-shadow: 0 16px 30px rgba(0, 0, 0, 0.42);
+    }
 
     .stats-hub {
       padding: 1rem;
@@ -268,6 +286,20 @@
       grid-template-columns: 1fr 1fr;
       gap: 0.75rem;
       margin: 2rem 0;
+    }
+    .action-strip .btn-cta,
+    .action-strip .btn-ghost {
+      min-height: 50px;
+      border-radius: 14px;
+      font-size: 0.78rem;
+      letter-spacing: 0.08em;
+      font-weight: 900;
+      box-shadow: 0 14px 28px rgba(0,0,0,0.35);
+      border-width: 1px;
+    }
+    .action-strip .btn-ghost {
+      border-color: rgba(168, 85, 247, 0.38);
+      background: linear-gradient(145deg, rgba(17,24,39,0.95), rgba(9,14,28,0.92));
     }
 
     .share-card-export-shell {
@@ -369,7 +401,7 @@
           </div>
           <div class="code-actions">
             <div class="badge-success text-xs">SYNCED</div>
-            <button class="btn-ghost auto btn-xs" id="copyCodeBtn" style="padding: 6px; border-radius: 8px;">
+            <button class="code-copy-btn" id="copyCodeBtn" aria-label="Copy access token">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><rect x="9" y="9" width="11" height="11" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
             </button>
           </div>
@@ -445,11 +477,11 @@
       <div class="action-strip">
         <button id="downloadBtn" class="btn-cta" data-i18n="downloadBtn">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          DOWNLOAD_ID
+          DOWNLOAD ID CARD
         </button>
         <button id="copyBtn" class="btn-ghost" data-i18n="copyBtn">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
-          SHARE_LINK
+          COPY / SHARE SETTINGS
         </button>
       </div>
 


### PR DESCRIPTION
### Motivation
- Simplify admin entry by opening the admin dashboard directly when landed (admin gating handled elsewhere). 
- Surface the new "Lab" practice area from the main portal navigation and demo link. 
- Improve UX of token copy/download actions and action buttons with updated styles.

### Description
- Modified `public/admin.html` to hide the legacy private gate by default and make the `#mainPanel` visible immediately, added `ADMIN_TOKEN_KEY` and configured `NexusAuth.TOKEN_KEY` to use it, and removed the prior token auto-check and boot-time gate flow in favor of directly calling `unlockAdminPanel()` on DOM ready. 
- Updated the admin API helper to continue using `NexusAuth.fetch` and maintain 401 handling with `logoutAdmin()`; preserved other admin utilities like export/copy helpers. 
- Updated `public/index.html` to add a top navigation link to `lab.html`, change the demo link target to `lab.html`, and update the demo anchor copy to advertise the AXP Lab. 
- Updated `public/result.html` to add styles for a new `code-copy-btn`, restyled `action-strip` buttons, replaced the old `copyCodeBtn` with the new styled button and aria-label, and adjusted button labels for download/copy actions.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9b9214ec832daca44db339f72b8b)