### PR TITLE
Admin token handling, admin panel fetch helper, Lab link and UI refinements

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -576,10 +576,44 @@
     let dashboardPoller = null;
     let allVendorsCache = [];
     let selectedTier = 'normal';
+    const ADMIN_TOKEN_KEY = 'axp_admin_token';
+
+    function getAdminToken() {
+      return localStorage.getItem(ADMIN_TOKEN_KEY) || '';
+    }
+
+    function setAdminToken(token) {
+      if (token) localStorage.setItem(ADMIN_TOKEN_KEY, token);
+    }
+
+    function clearAdminToken() {
+      localStorage.removeItem(ADMIN_TOKEN_KEY);
+    }
+
+    async function adminFetch(url, options = {}) {
+      const { autoRedirect401 = true, ...fetchOptions } = options;
+      const token = getAdminToken();
+      const headers = {
+        'Content-Type': 'application/json',
+        ...(fetchOptions.headers || {})
+      };
+      if (token) headers.Authorization = `Bearer ${token}`;
+      const res = await fetch(url, {
+        ...fetchOptions,
+        headers,
+        credentials: 'include'
+      });
+      if (autoRedirect401 && res.status === 401) {
+        clearAdminToken();
+        window.location.href = 'index.html?admin=required';
+        throw new Error('ADMIN_SESSION_REQUIRED');
+      }
+      return res;
+    }
 
     // ── API Helper ─────────────────────────────────────────────────
     async function api(path, method = 'GET', body = null) {
-      const res = await NexusAuth.fetch(path, {
+      const res = await adminFetch(path, {
         method,
         body: body ? JSON.stringify(body) : null
       });
@@ -608,7 +642,8 @@
         btn.disabled = true;
         status.textContent = 'CONNECTING...';
 
-        const res = await NexusAuth.fetch('/api/vault/admin/login', {
+        const res = await adminFetch('/api/vault/admin/login', {
+          autoRedirect401: false,
           method: 'POST',
           body: JSON.stringify({ password: pass })
         });
@@ -616,7 +651,7 @@
         try { payload = await res.json(); } catch(_) {}
 
         if (res.ok && (payload.type === 'admin' || payload.token)) {
-          if (payload.token) NexusAuth.setToken(payload.token);
+          if (payload.token) setAdminToken(payload.token);
           status.textContent = 'ACCESS_GRANTED ✓';
           setTimeout(unlockAdminPanel, 500);
         } else {
@@ -635,8 +670,9 @@
     }
 
     async function logoutAdmin() {
-      try { await NexusAuth.fetch('/api/vault/admin/logout', { method: 'POST' }); } catch(_) {}
-      NexusAuth.logout();
+      try { await adminFetch('/api/vault/admin/logout', { method: 'POST' }); } catch(_) {}
+      clearAdminToken();
+      window.location.href = 'index.html?logout=true';
     }
 
     function unlockAdminPanel() {
@@ -646,6 +682,11 @@
       loadDashboard();
       if (dashboardPoller) return;
       dashboardPoller = setInterval(() => loadDashboard().catch(()=>{}), 15000);
+    }
+
+    function showAdminGate() {
+      document.getElementById('mainPanel').classList.add('hidden');
+      document.getElementById('privateGate').classList.remove('hidden');
     }
 
     // ── Tab Navigation ─────────────────────────────────────────────
@@ -695,19 +736,17 @@
     async function loadDashboard() {
       try {
         const [stats, vendors, settings] = await Promise.all([
-          api('/api/vault/admin/stats').catch(() => ({})),
-          api('/api/vault/admin/vendors').catch(() => []),
-          api('/api/vault/admin/settings').catch(() => [])
+          api('/api/vault/admin/stats'),
+          api('/api/vault/admin/vendors'),
+          api('/api/vault/admin/settings')
         ]);
 
-        if (stats) {
-          document.getElementById('totalVendors').textContent = stats.vendors ?? 0;
-          document.getElementById('totalUsage').textContent = stats.usage_total ?? 0;
-          document.getElementById('totalCodes').textContent = stats.codes ?? 0;
-          const load = Math.min(100, Math.round((stats.usage_total || 0) / 10));
-          document.getElementById('loadVal').textContent = load + '%';
-          document.getElementById('loadBar').style.width = load + '%';
-        }
+        document.getElementById('totalVendors').textContent = stats?.vendors ?? 0;
+        document.getElementById('totalUsage').textContent = stats?.usage_total ?? 0;
+        document.getElementById('totalCodes').textContent = stats?.codes ?? 0;
+        const load = Math.min(100, Math.round((stats?.usage_total || 0) / 10));
+        document.getElementById('loadVal').textContent = load + '%';
+        document.getElementById('loadBar').style.width = load + '%';
 
         if (Array.isArray(settings)) {
           const offset = settings.find(s => s.setting_key === 'global_sensitivity_offset');
@@ -723,7 +762,11 @@
         document.getElementById('lastSyncLabel').textContent = 'SYNCED_' + new Date().toLocaleTimeString().split(' ')[0];
 
         loadLiveFeed();
-      } catch (e) { console.error('DASH_ERR:', e); }
+      } catch (e) {
+        console.error('DASH_ERR:', e);
+        document.getElementById('lastSyncLabel').textContent = 'SYNC_FAILED';
+        if (window.notify) window.notify(`ADMIN_SYNC_ERROR: ${e.message || 'UNKNOWN'}`, 'error');
+      }
     }
 
     // ── Org Analytics ─────────────────────────────────────────────
@@ -1081,23 +1124,19 @@
     }
 
     // ── Boot ──────────────────────────────────────────────────────
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', async () => {
       document.getElementById('adminPass').addEventListener('keydown', e => {
         if (e.key === 'Enter') checkPass();
       });
 
-      // Auto-unlock if session/cookie/token is active
-      const cachedToken = sessionStorage.getItem('axp_token') || localStorage.getItem('axp_token');
-      if (cachedToken) NexusAuth.setToken(cachedToken);
-      fetch('/api/vault/admin/stats', { credentials: 'include' })
-        .then(r => r.ok ? r.json() : null)
-        .then(data => {
-          if (data) unlockAdminPanel();
-          else document.getElementById('privateGate').classList.remove('hidden');
-        })
-        .catch(() => {
-          document.getElementById('privateGate').classList.remove('hidden');
-        });
+      try {
+        const probe = await adminFetch('/api/vault/admin/stats', { autoRedirect401: false });
+        if (!probe.ok) throw new Error(`ADMIN_BOOT_${probe.status}`);
+        unlockAdminPanel();
+      } catch (err) {
+        showAdminGate();
+        if (window.notify) window.notify('ADMIN_SESSION_REQUIRED — ENTER_ADMIN_SECRET', 'error');
+      }
     });
   </script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -451,6 +451,7 @@
     <div class="portal-logo">AXP_CORE</div>
     <div class="portal-top-links">
       <a href="stats.html" class="portal-top-link">Global</a>
+      <a href="lab.html" class="portal-top-link">Lab</a>
       <a href="generator.html" class="portal-top-link">Demo</a>
     </div>
   </header>
@@ -501,9 +502,9 @@
 
       <div class="vault-or">OR</div>
 
-      <a href="generator.html" class="vault-demo-link">
+      <a href="lab.html" class="vault-demo-link">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-        Try free demo — no code needed
+        Open AXP Lab — free practice mode
       </a>
     </div>
 
@@ -520,6 +521,7 @@
   <footer class="portal-footer" role="contentinfo">
     <a href="privacy.html">Privacy</a>
     <a href="terms.html">Terms</a>
+    <a href="lab.html">Lab</a>
     <a href="support.html">Support</a>
     <a href="stats.html">Platform Stats</a>
   </footer>
@@ -601,7 +603,10 @@
         updateStatus('INITIALIZING_ADMIN_DECRYPT...', 'active');
         const { res: adminRes, data: aData } = await portalRequest('/api/vault/admin/login', { password: key });
         if (adminRes.ok) {
-          if (aData.token) NexusAuth.setToken(aData.token);
+          if (aData.token) {
+            NexusAuth.setToken(aData.token);
+            localStorage.setItem('axp_admin_token', aData.token);
+          }
           updateStatus('ADMIN_UPLINK_GRANTED', 'success');
           btn.textContent = 'ACCESS GRANTED ✓';
           setTimeout(() => window.location.href = 'admin.html', 700);

--- a/public/result.html
+++ b/public/result.html
@@ -184,6 +184,24 @@
       align-items: center;
       gap: 10px;
     }
+    .code-copy-btn {
+      min-width: 42px;
+      min-height: 42px;
+      border-radius: 12px;
+      border: 1px solid rgba(168, 85, 247, 0.42);
+      background: linear-gradient(145deg, rgba(168, 85, 247, 0.2), rgba(0, 229, 255, 0.08));
+      color: var(--tx-hero);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 10px 26px rgba(0, 0, 0, 0.35);
+      transition: transform 0.2s var(--ease), box-shadow 0.2s var(--ease), border-color 0.2s;
+    }
+    .code-copy-btn:hover {
+      transform: translateY(-1px);
+      border-color: rgba(0, 229, 255, 0.48);
+      box-shadow: 0 16px 30px rgba(0, 0, 0, 0.42);
+    }
 
     .stats-hub {
       padding: 1rem;
@@ -268,6 +286,20 @@
       grid-template-columns: 1fr 1fr;
       gap: 0.75rem;
       margin: 2rem 0;
+    }
+    .action-strip .btn-cta,
+    .action-strip .btn-ghost {
+      min-height: 50px;
+      border-radius: 14px;
+      font-size: 0.78rem;
+      letter-spacing: 0.08em;
+      font-weight: 900;
+      box-shadow: 0 14px 28px rgba(0,0,0,0.35);
+      border-width: 1px;
+    }
+    .action-strip .btn-ghost {
+      border-color: rgba(168, 85, 247, 0.38);
+      background: linear-gradient(145deg, rgba(17,24,39,0.95), rgba(9,14,28,0.92));
     }
 
     .share-card-export-shell {
@@ -369,7 +401,7 @@
           </div>
           <div class="code-actions">
             <div class="badge-success text-xs">SYNCED</div>
-            <button class="btn-ghost auto btn-xs" id="copyCodeBtn" style="padding: 6px; border-radius: 8px;">
+            <button class="code-copy-btn" id="copyCodeBtn" aria-label="Copy access token">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><rect x="9" y="9" width="11" height="11" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
             </button>
           </div>
@@ -445,11 +477,11 @@
       <div class="action-strip">
         <button id="downloadBtn" class="btn-cta" data-i18n="downloadBtn">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          DOWNLOAD_ID
+          DOWNLOAD ID CARD
         </button>
         <button id="copyBtn" class="btn-ghost" data-i18n="copyBtn">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
-          SHARE_LINK
+          COPY / SHARE SETTINGS
         </button>
       </div>
 


### PR DESCRIPTION
### Motivation

- Persist and isolate admin session tokens separately from the general `NexusAuth` flow and provide robust 401 handling for the admin UI.
- Improve boot/auto-unlock behavior of the admin panel and surface sync errors to the operator.
- Expose an AXP Lab entry point and polish several UI affordances on the public portal and result pages.

### Description

- Added `ADMIN_TOKEN_KEY`, `getAdminToken`, `setAdminToken`, `clearAdminToken` and a new `adminFetch` helper in `public/admin.html` to attach an admin token from `localStorage`, include credentials, and auto-redirect on 401s.
- Replaced direct uses of `NexusAuth.fetch` with `adminFetch` for admin endpoints and updated `checkPass` and `logoutAdmin` to set/clear the admin token and redirect appropriately, plus added `showAdminGate` and improved `loadDashboard` error handling and notifications.
- On the public portal (`public/index.html`) store the admin token on successful admin login (`localStorage.setItem('axp_admin_token', ...)`) and add links to `lab.html` (header, demo link, footer) to surface the AXP Lab mode.
- UI/CSS tweaks in `public/result.html` including a styled `code-copy-btn`, updated `action-strip` button styles, and revised action button labels and copy/share text.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9b9214ec832daca44db339f72b8b)